### PR TITLE
CI: Require doc team signoff for doc changes

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -30,3 +30,14 @@ groups:
     required: 2
     teams:
       - documentation
+
+  documentation:
+    required: 1
+    teams:
+      - documentation
+    conditions:
+      files:
+        include:
+          - "*.md"
+        exclude:
+          - "vendor/*"


### PR DESCRIPTION
Require an additional approval from a `documentation` team member for
PRs containing documentation changes.

Fixes #4.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>