### PR TITLE
docs: Improve command to enable agent debug

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -65,6 +65,7 @@ If your system is *not* able to run Kata Containers, the previous command will e
 ## Enable full debug
 
 Enable full debug as follows:
+
 ```
 $ sudo sed -i -e 's/^# *\(enable_debug\).*=.*$/\1 = true/g' /usr/share/defaults/kata-containers/configuration.toml
 $ sudo sed -i -e 's/^kernel_params = ""/kernel_params = "agent.log=debug"/g' /usr/share/defaults/kata-containers/configuration.toml

--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -68,7 +68,7 @@ Enable full debug as follows:
 
 ```
 $ sudo sed -i -e 's/^# *\(enable_debug\).*=.*$/\1 = true/g' /usr/share/defaults/kata-containers/configuration.toml
-$ sudo sed -i -e 's/^kernel_params = ""/kernel_params = "agent.log=debug"/g' /usr/share/defaults/kata-containers/configuration.toml
+$ sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' /usr/share/defaults/kata-containers/configuration.toml
 ```
 
 # Build and install Kata proxy


### PR DESCRIPTION
Change the command to enable agent debug slightly so that even if the
config file specifies kernel parameters, the command will successfully
enable the agent debug.

Fixes #38.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>