### PR TITLE
dev-guide: Conditionally add kata-runtime as suffix

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -185,7 +185,7 @@ $ dir=/etc/systemd/system/docker.service.d
 $ file="$dir/kata-containers.conf"
 $ sudo mkdir -p "$dir"
 $ sudo test -e "$file" || echo -e "[Service]\nType=simple\nExecStart=\nExecStart=/usr/bin/dockerd -D --default-runtime runc" | sudo tee "$file"
-$ sudo sed -i 's!^\(ExecStart=[^$].*$\)!\1 --add-runtime kata-runtime=/usr/local/bin/kata-runtime!g' "$file"
+$ sudo grep -q "kata-runtime=" $file || sudo sed -i 's!^\(ExecStart=[^$].*$\)!\1 --add-runtime kata-runtime=/usr/local/bin/kata-runtime!g' "$file"
 $ sudo systemctl daemon-reload
 $ sudo systemctl restart docker
 ```


### PR DESCRIPTION
If kata-runtime is already added as a runtime to kata-containers.conf 
then you need not add it again.  This is helful when we redo some
of the earlier steps and endup updating docker config again resulting 
in multiple "--add-runtime kata-runtime=.." which furthur results in failure 
in docker restart. 

Fixes #49

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com