### PR TITLE
docs: Add license strategy doc

### DIFF
--- a/Licensing-strategy.md
+++ b/Licensing-strategy.md
@@ -1,0 +1,25 @@
+# Licensing strategy
+
+* [Project License](#project-license)
+* [License file](#license-file)
+* [License for individual files](#license-for-individual-files)      
+
+## Project License
+
+The license for the [Kata Containers](https://github.com/kata-containers)
+project is [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+## License file
+
+All repositories in the project have a top level file called `LICENSE`. This
+file lists full details of all licences used by the repository.
+
+## License for individual files
+
+Where possible all files in all repositories also contain a
+[SPDX](https://spdx.org) license identifier. This provides fine-grained
+licensing and allows automated tooling to check the license of individual
+files.
+
+This SPDX licence identifier requirement is enforced by the
+[CI (Continuous Integration) system](https://github.com/kata-containers/tests/blob/master/.ci/static-checks.sh).


### PR DESCRIPTION
Add a brief document explaining that the project uses SPDX license
identifiers.

Fixes #58.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>