### PR TITLE
docs: Fix release checklist link in releases doc

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -65,7 +65,7 @@ Note that although hypervisor and guest kernel both have versions, these are not
 
 ## Release checklist
 
-The detailed steps to follow to create a new release are specified in the [Release Checklist](#Release-Checklist).
+The detailed steps to follow to create a new release are specified in the [Release Checklist](Release-Checklist.md).
 
 ## Release process
 


### PR DESCRIPTION
The link to the release checklist in the Releases document was linking
to the parent document, not the separate checklist document.

Fixes #73.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>