### PR TITLE
docs: Make runtime use qemu-lite in dev guide

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -54,7 +54,8 @@ This document is written **specifically for developers**.
 ```
 $ go get -d -u github.com/kata-containers/runtime
 $ cd $GOPATH/src/github.com/kata-containers/runtime
-$ make && sudo -E PATH=$PATH make install
+$ export QEMUPATH=/usr/bin/qemu-lite-system-$(arch)
+$ make QEMUPATH="${QEMUPATH}" && sudo -E PATH=$PATH make install QEMUPATH="${QEMUPATH}"
 ```
 
 The build will create the following:

--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -35,6 +35,10 @@ This document is written **specifically for developers**.
 - You already have the following installed:
   - [Docker](https://www.docker.com/).
   - [golang](https://golang.org/dl) version 1.8.3 or newer.
+
+    To view the versions of go known to work, see the `golang` entry in the
+    [versions database](https://github.com/kata-containers/runtime/blob/master/versions.yaml).
+
   - `make`.
   - `gcc` (required for building the shim and runtime).
 


### PR DESCRIPTION
Updated the developer guide to ensure when the developer builds the
runtime that they have it pre-configured to use `qemu-lite`, since this
matches the OBS packaged runtime behaviour.

Fixes #89.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>