### PR TITLE
docs: Change install guides to use bash code blocks

### DIFF
--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -6,7 +6,7 @@ Kata Containers is available for Fedora\* versions **26** and **27**.
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:
 
-```
+```bash
 $ sudo dnf -y install dnf-plugins-core
 $ sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
 $ sudo dnf makecache
@@ -18,7 +18,7 @@ For more information on installing Docker please refer to the
 
 2. Install the Kata Containers components with the following commands:
 
-```
+```bash
 $ source /etc/os-release
 $ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo \
 https://download.opensuse.org/repositories/home:/katacontainers:/release/Fedora\_$VERSION_ID/home:katacontainers:release.repo
@@ -27,7 +27,7 @@ $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
 
 3. Configure Docker to use Kata Containers by default with the following commands:
 
-```
+```bash
 $ sudo mkdir -p /etc/systemd/system/docker.service.d/
 $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
 [Service]
@@ -38,7 +38,7 @@ EOF
 
 4. Restart the Docker systemd service with the following commands:
 
-```
+```bash
 $ sudo systemctl daemon-reload
 $ sudo systemctl restart docker
 ```
@@ -47,6 +47,6 @@ $ sudo systemctl restart docker
 
 You are now ready to run Kata Containers:
 
-```
+```bash
 $ sudo docker run -ti busybox sh
 ```

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -8,7 +8,7 @@ Currently Kata Containers is currently only build for x86_64.
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:
 
-```
+```bash
 $ sudo -E apt-get -y install apt-transport-https ca-certificates wget software-properties-common
 $ curl -sL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 $ arch=$(dpkg --print-architecture)
@@ -22,7 +22,7 @@ For more information on installing Docker please refer to the
 
 2. Install the Kata Containers components with the following commands:
 
-```
+```bash
 $ sudo sh -c "echo 'deb https://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' >> /etc/apt/sources.list.d/kata-containers.list"
 $ curl -sL  https://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
 $ sudo -E apt-get update
@@ -31,7 +31,7 @@ $ sudo -E apt-get -y install kata-runtime kata-proxy kata-shim
 
 3. Configure Docker to use Kata Containers by default with the following commands:
 
-```
+```bash
 $ sudo mkdir -p /etc/systemd/system/docker.service.d/
 $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
 [Service]
@@ -42,7 +42,7 @@ EOF
 
 4. Restart the Docker systemd service with the following commands:
 
-```
+```bash
 $ sudo systemctl daemon-reload
 $ sudo systemctl restart docker
 ```
@@ -51,6 +51,6 @@ $ sudo systemctl restart docker
 
 You are now ready to run Kata Containers:
 
-```
+```bash
 $ sudo docker run -ti busybox sh
 ```


### PR DESCRIPTION
Change the installation guides so that all commands the user must type
use an explicit bash code block rather than a standard code block.

This adds meaning to the documents and will then allow us to extract
the commands and run them for testing purposes.

Fixes #92.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>