### PR TITLE
CI: Add CI scripts

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+export tests_repo_dir="$GOPATH/src/$tests_repo"
+
+clone_tests_repo()
+{
+	# KATA_CI_NO_NETWORK is (has to be) ignored if there is
+	# no existing clone.
+	if [ -d "$tests_repo_dir" -a -n "$KATA_CI_NO_NETWORK" ]
+	then
+		return
+	fi
+
+	go get -d -u "$tests_repo" || true
+}
+
+run_static_checks()
+{
+	clone_tests_repo
+	bash "$tests_repo_dir/.ci/static-checks.sh"
+}

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+cidir=$(dirname "$0")
+bash "${cidir}/static-checks.sh"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+run_static_checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+dist: trusty
+
+language: bash
+
+script:
+  - ".ci/run.sh"


### PR DESCRIPTION
Create a basic set of CI scripts that just run the static checks for
now.

Fixes #101.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>