### PR TITLE
docs: Make Ubuntu install idempotent

### DIFF
--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -24,7 +24,7 @@ For more information on installing Docker please refer to the
 
   **Note:** The repository is downloading content using `http`, be aware that this installation channel is not secure.
 ```bash
-$ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' >> /etc/apt/sources.list.d/kata-containers.list"
+$ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
 $ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
 $ sudo -E apt-get update
 $ sudo -E apt-get -y install kata-runtime kata-proxy kata-shim


### PR DESCRIPTION
Don't append to Kata-specific apt sources file to avoid apt warnings
and make the install idempotent.

Fixes #107.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>