### PR TITLE
docs: Ensure install doc bash commands are non-interactive

### DIFF
--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -48,6 +48,6 @@ $ sudo systemctl restart docker
 
 You are now ready to run Kata Containers:
 
-```bash
+```
 $ sudo docker run -ti busybox sh
 ```

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -52,6 +52,6 @@ $ sudo systemctl restart docker
 
 You are now ready to run Kata Containers:
 
-```bash
+```
 $ sudo docker run -ti busybox sh
 ```


### PR DESCRIPTION
Remove the `bash` tag from the last command in the install guides where
we show the user how to create a container with a busybox shell. This
doesn't change the content of the document but it ensures that all bash
blocks can be run non-interactively (by the `kata-doc-to-script.sh`
script in the tests repo).

Fixes #109.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>