### PR TITLE
install: Fix centos obs url

### DIFF
--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -19,7 +19,7 @@ For more information on installing Docker please refer to the
 ```bash
 $ source /etc/os-release
 $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo \
-http://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_\$VERSION_ID/home:katacontainers:release.repo
+"http://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_${VERSION_ID}/home:katacontainers:release.repo"
 $ sudo -E yum -y install kata-runtime kata-proxy kata-shim
 ```
 


### PR DESCRIPTION
Remove backslash from centos url that was
preventing the $VERSION_ID to take its correct value.

Fixes: #112.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>