### PR TITLE
docs: Fix CentOS install guide

### DIFF
--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -6,7 +6,7 @@ This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:
 
 ```bash
-$ sudo yum -y install dnf-plugins-core
+$ sudo yum -y install yum-utils
 $ sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 $ sudo yum -y install docker-ce
 ```


### PR DESCRIPTION
The CentOS install guide was referencing an invalid package
(`dnf-plugins-core`) so update for the yum equivalent.

Fixes #329.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>