### PR TITLE
docs: Make devguide refer to install README

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -46,12 +46,9 @@ This document is written **specifically for developers**: it is not intended for
 
 # Initial setup
 
-The recommended way to create a development environment is to first install the
-packaged versions of the Kata Containers components to create a working
-system:
-
-  * [Fedora\*](install/fedora-installation-guide.md)
-  * [Ubuntu\*](install/ubuntu-installation-guide.md)
+The recommended way to create a development environment is to first
+[install the packaged versions of the Kata Containers components](install/README.md)
+to create a working system.
 
 The installation guide instructions will install all required Kata Containers
 components, plus Docker*, the hypervisor, and the Kata Containers image and


### PR DESCRIPTION
Now that we have a README for the installation guides, update the
developer guide to refer to that page, to avoid hard-coding links to
(some of) the installation guides.

Fixes #117.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>