### PR TITLE
Add links to upgrade doc

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -8,5 +8,6 @@ Select your preferred distribution:
 
 For further information, see:
 
+* The [the upgrading document](../Upgrading.md).
 * The [developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md)
 * The [runtime documentation](https://github.com/kata-containers/runtime/blob/master/README.md)

--- a/install/README.md
+++ b/install/README.md
@@ -9,5 +9,5 @@ Select your preferred distribution:
 For further information, see:
 
 * The [the upgrading document](../Upgrading.md).
-* The [developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md)
-* The [runtime documentation](https://github.com/kata-containers/runtime/blob/master/README.md)
+* The [developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md).
+* The [runtime documentation](https://github.com/kata-containers/runtime/blob/master/README.md).

--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -1,6 +1,6 @@
 # Installing Kata Containers on CentOS
 
-Note: Kata Containers is available for CentOS version 7.
+> **Note:** Kata Containers is available for CentOS version 7.
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:
@@ -15,7 +15,8 @@ For more information on installing Docker please refer to the
 
 2. Install the Kata Containers components with the following commands:
 
-  **Note:** The repository redirects the download content to use `http`, be aware that this installation channel is not secure.
+> **Note:** The repository redirects the download content to use `http`, be aware that this installation channel is not secure.
+
 ```bash
 $ source /etc/os-release
 $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo \

--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -1,6 +1,11 @@
 # Installing Kata Containers on CentOS
 
-> **Note:** Kata Containers packages are available for CentOS version 7 (currently `x86_64` only).
+> **Notes:**
+>
+> - Kata Containers packages are available for CentOS version 7 (currently `x86_64` only).
+>
+> - If you are installing on a system that already has Clear Containers or `runv` installed,
+>   first read [the upgrading document](../Upgrading.md).
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:

--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -1,6 +1,6 @@
 # Installing Kata Containers on CentOS
 
-> **Note:** Kata Containers is available for CentOS version 7.
+> **Note:** Kata Containers packages are available for CentOS version 7 (currently `x86_64` only).
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -1,6 +1,11 @@
 # Installing Kata Containers on Fedora
 
-> **Note:** Kata Containers packages are available for Fedora\* versions **26** and **27** (currently `x86_64` only).
+> **Notes:**
+>
+> - Kata Containers packages are available for Fedora\* versions **26** and **27** (currently `x86_64` only).
+>
+> - If you are installing on a system that already has Clear Containers or `runv` installed,
+>   first read [the upgrading document](../Upgrading.md).
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -1,6 +1,6 @@
 # Installing Kata Containers on Fedora
 
-> **Note:** Kata Containers is available for Fedora\* versions **26** and **27**.
+> **Note:** Kata Containers packages are available for Fedora\* versions **26** and **27** (currently `x86_64` only).
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -1,7 +1,6 @@
 # Installing Kata Containers on Fedora
 
-Note:
-Kata Containers is available for Fedora\* versions **26** and **27**.
+> **Note:** Kata Containers is available for Fedora\* versions **26** and **27**.
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:
@@ -18,7 +17,8 @@ For more information on installing Docker please refer to the
 
 2. Install the Kata Containers components with the following commands:
 
-  **Note:** The repository redirects the download content to use `http`, be aware that this installation channel is not secure.
+> **Note:** The repository redirects the download content to use `http`, be aware that this installation channel is not secure.
+
 ```bash
 $ source /etc/os-release
 $ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo \

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -1,7 +1,7 @@
 # Installing Kata Containers on Ubuntu
 
-Note:
-Kata Containers is available for Ubuntu\* **16.04** and **17.10**.
+> **Note:** Kata Containers is available for Ubuntu\* **16.04** and **17.10**.
+
 Currently Kata Containers is currently only build for x86_64.
 
 
@@ -22,7 +22,8 @@ For more information on installing Docker please refer to the
 
 2. Install the Kata Containers components with the following commands:
 
-  **Note:** The repository is downloading content using `http`, be aware that this installation channel is not secure.
+> **Note:** The repository is downloading content using `http`, be aware that this installation channel is not secure.
+
 ```bash
 $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
 $ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -1,9 +1,6 @@
 # Installing Kata Containers on Ubuntu
 
-> **Note:** Kata Containers is available for Ubuntu\* **16.04** and **17.10**.
-
-Currently Kata Containers is currently only build for x86_64.
-
+> **Note:** Kata Containers packages are available for Ubuntu\* **16.04** and **17.10** (currently `x86_64` only).
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -1,6 +1,11 @@
 # Installing Kata Containers on Ubuntu
 
-> **Note:** Kata Containers packages are available for Ubuntu\* **16.04** and **17.10** (currently `x86_64` only).
+> **Notes:**
+>
+> - Kata Containers packages are available for Ubuntu\* **16.04** and **17.10** (currently `x86_64` only).
+>
+> - If you are installing on a system that already has Clear Containers or `runv` installed,
+>   first read [the upgrading document](../Upgrading.md).
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:


### PR DESCRIPTION
- Make the leading Note in the install guides use the standard note formatting.
- Update the install guides to explain that packages are currently only available on x86_64.
- Update the install README and the install guides to point to the upgrading document.
- Add fullstops at the of bullets in install README.

Fixes #119.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>