### PR TITLE
Ubunut/Kata: upgrade from clear container to kata container

### DIFF
--- a/Upgrading.md
+++ b/Upgrading.md
@@ -89,14 +89,14 @@ Kata Containers configuration.
 ### Fedora
 
 ```
-$ sudo -E dnf remove cc-runtime\* cc-proxy\* cc-shim\* linux-container clear-containers-image qemu-lite
+$ sudo -E dnf remove cc-runtime\* cc-proxy\* cc-shim\* linux-container clear-containers-image qemu-lite cc-ksm-throttler
 $ sudo rm /etc/yum.repos.d/home:clearcontainers:clear-containers-3.repo
 ```
 
 ### Ubuntu
 
 ```
-$ sudo apt-get purge cc-runtime\* cc-proxy\* cc-shim\* linux-container clear-containers-image qemu-lite
+$ sudo apt-get purge cc-runtime\* cc-proxy\* cc-shim\* linux-container clear-containers-image qemu-lite cc-ksm-throttler
 $ sudo rm /etc/apt/sources.list.d/clear-containers.list
 ```
 


### PR DESCRIPTION
Hit below error when upgrading on Ubuntu:
    The following packages have unmet dependencies:
    kata-runtime : Depends: kata-ksm-throttler (>= 1.0.0+git.422c7f7-28)
    but it is not going to be installed
Fix it by:
    sudo dpkg -P cc-ksm-throttler

Signed-off-by: Liu Changcheng <changcheng.liu@intel.com>