### PR TITLE
CI: test installation guides

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -8,4 +8,4 @@
 set -e
 
 cidir=$(dirname "$0")
-bash "${cidir}/test-install-docs.sh"
+bash "${cidir}/static-checks.sh"

--- a/.ci/test-install-docs.sh
+++ b/.ci/test-install-docs.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+info()
+{
+	msg="$*"
+	echo "INFO: $msg"
+}
+
+# Detect if any installation guides changed. If so, run the
+# kata manager to "execute" the install guide to ensure the
+# commands it specified result in a working system.
+check_install_guides()
+{
+	local -r install_guide_suffix="-installation-guide.md"
+
+	# List of filters used to restrict the types of file changes.
+	# See git-diff-tree(1) for further info.
+	local filters=""
+
+	# Added file
+	filters+="A"
+
+	# Copied file
+	filters+="C"
+
+	# Modified file
+	filters+="M"
+
+	# Renamed file
+	filters+="R"
+
+	# Unmerged (U) and Unknown (X) files. These particular filters
+	# shouldn't be necessary but just in case...
+	filters+="UX"
+
+	# List of changed files
+	local files=$(git diff-tree \
+		--name-only \
+		--no-commit-id \
+		--diff-filter="${filters}" \
+		-r \
+		origin/master HEAD || true)
+
+	# No files were changed
+	[ -z "$files" ] && return
+
+	changed=$(echo "$files" | grep "install/.*${install_guide_suffix}$" || true)
+
+	[ -z "$changed" ] && info "No install guides modified" && return
+
+	info "Found modified install guides: $changed"
+
+	# Regardless of which distro install guide(s) were changed, we test
+	# them all where possible.
+
+	local -r GOPATH=$(go env GOPATH)
+	[ -z "$GOPATH" ] && die "cannot determine GOPATH"
+
+	local -r mgr="${GOPATH}/src/github.com/kata-containers/tests/cmd/kata-manager/kata-manager.sh"
+
+	[ ! -e "$GOPATH" ] && die "cannot find $mgr"
+
+	source /etc/os-release
+
+	info "Installing system from the $ID install guide"
+
+	$mgr install-packages
+
+	[ -n "$TRAVIS" ] && info "Not creating container as Travis lacks VT-x" && return 
+
+	$mgr configure-image
+	$mgr enable-debug
+
+	msg="INFO: Successfully tested install guide for distro '$ID' $VERSION"
+
+	# Perform a basic test
+	sudo -E docker run --rm -i --runtime "kata-runtime" busybox echo "$msg"
+}
+
+check_install_guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ dist: trusty
 
 language: bash
 
+before_script:
+  - ".ci/setup.sh"
+
 script:
   - ".ci/run.sh"


### PR DESCRIPTION
Moved static tests to CI setup script and added a new CI test to execute
all install guides if any one changes.

Fixes #132.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>