### PR TITLE
reference to hardware requirements

### DIFF
--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -30,8 +30,9 @@ $ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo \
 http://download.opensuse.org/repositories/home:/katacontainers:/release/Fedora\_$VERSION_ID/home:katacontainers:release.repo
 $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
 ```
+3. Check [hardware requirements](https://github.com/kata-containers/runtime/#hardware-requirements)
 
-3. Configure Docker to use Kata Containers by default with the following commands:
+4. Configure Docker to use Kata Containers by default with the following commands:
 
 ```bash
 $ sudo mkdir -p /etc/systemd/system/docker.service.d/
@@ -42,7 +43,7 @@ ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime -
 EOF
 ```
 
-4. Restart the Docker systemd service with the following commands:
+5. Restart the Docker systemd service with the following commands:
 
 ```bash
 $ sudo systemctl daemon-reload


### PR DESCRIPTION
docs: Add a section "hardware requirements" on Fedora installation guide.

Fixes [#373](https://github.com/kata-containers/runtime/issues/373).

Signed-off-by: Newton Jose <josephnewton001@gmail.com