### PR TITLE
docs: Split docker install into separate docs

### DIFF
--- a/.ci/test-install-docs.sh
+++ b/.ci/test-install-docs.sh
@@ -17,6 +17,8 @@ info()
 # commands it specified result in a working system.
 check_install_guides()
 {
+	[ -n "$TRAVIS" ] && info "Not testing install guide as Travis lacks modern distro support and VT-x" && return 
+
 	local -r install_guide_suffix="-installation-guide.md"
 
 	# List of filters used to restrict the types of file changes.
@@ -70,9 +72,7 @@ check_install_guides()
 
 	info "Installing system from the $ID install guide"
 
-	$mgr install-packages
-
-	[ -n "$TRAVIS" ] && info "Not creating container as Travis lacks VT-x" && return 
+	$mgr install-docker-system
 
 	$mgr configure-image
 	$mgr enable-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+sudo: required
 dist: trusty
 
 language: bash

--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -8,53 +8,26 @@
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
 >
-> - This install guide is specific to integration with Docker.  If you want to use Kata
->   Containers through Kubernetes, see the "Developer Guide" [here](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes).
+> - If you do not want to copy or type all these instructions by hand, you can use the
+>   [`kata-manager`](https://github.com/kata-containers/tests/blob/master/cmd/kata-manager/kata-manager.sh)
+>   script to install the packaged system including your chosen container
+>   manager. Alternatively, you can generate a runnable shell script from
+>   individual documents using the
+>   [`kata-doc-to-script`](https://github.com/kata-containers/tests/blob/master/.ci/kata-doc-to-script.sh) script.
 
-This step is only required in case Docker is not installed on the system.
-1. Install the latest version of Docker with the following commands:
+1. Install the Kata Containers components with the following commands:
 
-```bash
-$ sudo yum -y install yum-utils
-$ sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-$ sudo yum -y install docker-ce
-```
-For more information on installing Docker please refer to the
-[Docker Guide](https://docs.docker.com/engine/installation/linux/centos)
+   > **Note:** This installation channel is not secure since the repository currently
+   > redirects download URLs to `http`.
 
-2. Install the Kata Containers components with the following commands:
+   ```bash
+   $ source /etc/os-release
+   $ sudo yum -y install yum-utils
+   $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_${VERSION_ID}/home:katacontainers:release.repo"
+   $ sudo -E yum -y install kata-runtime kata-proxy kata-shim
+   ```
 
-> **Note:** The repository redirects the download content to use `http`, be aware that this installation channel is not secure.
+2. Decide which container manager you will use and select the corresponding link that follows:
 
-```bash
-$ source /etc/os-release
-$ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo \
-"http://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_${VERSION_ID}/home:katacontainers:release.repo"
-$ sudo -E yum -y install kata-runtime kata-proxy kata-shim
-```
-
-3. Configure Docker to use Kata Containers by default with the following commands:
-
-```bash
-$ sudo mkdir -p /etc/systemd/system/docker.service.d/
-$ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
-[Service]
-ExecStart=
-ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
-EOF
-```
-
-4. Restart the Docker systemd service with the following commands:
-
-```bash
-$ sudo systemctl daemon-reload
-$ sudo systemctl restart docker
-```
-
-5. Run Kata Containers
-
-You are now ready to run Kata Containers:
-
-```
-$ sudo docker run -ti busybox sh
-```
+   - [Docker](docker/centos-docker-install.md)
+   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes)

--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -2,7 +2,8 @@
 
 > **Notes:**
 >
-> - Kata Containers packages are available for CentOS version 7 (currently `x86_64` only).
+> - Kata Containers packages are available for [CentOS\*](https://www.centos.org)
+>   version 7 (currently `x86_64` only).
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).

--- a/install/docker/centos-docker-install.md
+++ b/install/docker/centos-docker-install.md
@@ -1,0 +1,54 @@
+# Install Docker for Kata Containers on CentOS
+
+> **Note:**
+>
+> - This guide assumes you have
+>   [already installed the Kata Containers packages](../centos-installation-guide.md).
+>
+> - If you do not want to copy or type all these instructions by hand, you can use the
+>   [`kata-manager`](https://github.com/kata-containers/tests/blob/master/cmd/kata-manager/kata-manager.sh)
+>   script to install the packaged system including your chosen container
+>   manager. Alternatively, you can generate a runnable shell script from
+>   individual documents using the
+>   [`kata-doc-to-script`](https://github.com/kata-containers/tests/blob/master/.ci/kata-doc-to-script.sh) script.
+
+1. Install the latest version of Docker with the following commands:
+
+   > **Note:** This step is only required if Docker is not installed on the system.
+
+   ```bash
+   $ sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+   $ sudo yum -y install docker-ce
+   ```
+
+   For more information on installing Docker please refer to the
+   [Docker Guide](https://docs.docker.com/engine/installation/linux/centos).
+
+2. Configure Docker to use Kata Containers by default with the following commands:
+
+   ```bash
+   $ sudo mkdir -p /etc/systemd/system/docker.service.d/
+   $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
+   [Service]
+   ExecStart=
+   ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+   EOF
+   ```
+
+3. Restart the Docker systemd service with the following commands:
+
+   ```bash
+   $ sudo systemctl daemon-reload
+   $ sudo systemctl restart docker
+   ```
+
+4. Run Kata Containers
+
+   You are now ready to run Kata Containers:
+
+   ```bash
+   $ sudo docker run -ti busybox uname -a
+   ```
+
+   The previous command shows details of the kernel version running inside the
+   container, which is different to the host kernel version.

--- a/install/docker/fedora-docker-install.md
+++ b/install/docker/fedora-docker-install.md
@@ -1,0 +1,55 @@
+# Install Docker for Kata Containers on Fedora
+
+> **Note:**
+>
+> - This guide assumes you have
+>   [already installed the Kata Containers packages](../fedora-installation-guide.md).
+>
+> - If you do not want to copy or type all these instructions by hand, you can use the
+>   [`kata-manager`](https://github.com/kata-containers/tests/blob/master/cmd/kata-manager/kata-manager.sh)
+>   script to install the packaged system including your chosen container
+>   manager. Alternatively, you can generate a runnable shell script from
+>   individual documents using the
+>   [`kata-doc-to-script`](https://github.com/kata-containers/tests/blob/master/.ci/kata-doc-to-script.sh) script.
+
+1. Install the latest version of Docker with the following commands:
+
+   > **Note:** This step is only required if Docker is not installed on the system.
+
+   ```bash
+   $ sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+   $ sudo dnf makecache
+   $ sudo dnf -y install docker-ce
+   ```
+
+   For more information on installing Docker please refer to the
+   [Docker Guide](https://docs.docker.com/engine/installation/linux/fedora).
+
+2. Configure Docker to use Kata Containers by default with the following commands:
+
+   ```bash
+   $ sudo mkdir -p /etc/systemd/system/docker.service.d/
+   $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
+   [Service]
+   ExecStart=
+   ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+   EOF
+   ```
+
+3. Restart the Docker systemd service with the following commands:
+
+   ```bash
+   $ sudo systemctl daemon-reload
+   $ sudo systemctl restart docker
+   ```
+
+4. Run Kata Containers
+
+   You are now ready to run Kata Containers:
+
+   ```bash
+   $ sudo docker run -ti busybox uname -a
+   ```
+
+   The previous command shows details of the kernel version running inside the
+   container, which is different to the host kernel version.

--- a/install/docker/ubuntu-docker-install.md
+++ b/install/docker/ubuntu-docker-install.md
@@ -1,0 +1,58 @@
+# Install Docker for Kata Containers on Ubuntu
+
+> **Note:**
+>
+> - This guide assumes you have
+>   [already installed the Kata Containers packages](../ubuntu-installation-guide.md).
+>
+> - If you do not want to copy or type all these instructions by hand, you can use the
+>   [`kata-manager`](https://github.com/kata-containers/tests/blob/master/cmd/kata-manager/kata-manager.sh)
+>   script to install the packaged system including your chosen container
+>   manager. Alternatively, you can generate a runnable shell script from
+>   individual documents using the
+>   [`kata-doc-to-script`](https://github.com/kata-containers/tests/blob/master/.ci/kata-doc-to-script.sh) script.
+
+1. Install the latest version of Docker with the following commands:
+
+   > **Note:** This step is only required if Docker is not installed on the system.
+
+   ```bash
+   $ sudo -E apt-get -y install apt-transport-https ca-certificates software-properties-common
+   $ curl -sL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+   $ arch=$(dpkg --print-architecture)
+   $ sudo -E add-apt-repository "deb [arch=${arch}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+   $ sudo -E apt-get update
+   $ sudo -E apt-get -y install docker-ce
+   ```
+
+   For more information on installing Docker please refer to the
+   [Docker Guide](https://docs.docker.com/engine/installation/linux/ubuntu).
+
+2. Configure Docker to use Kata Containers by default with the following commands:
+
+   ```bash
+   $ sudo mkdir -p /etc/systemd/system/docker.service.d/
+   $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
+   [Service]
+   ExecStart=
+   ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+   EOF
+   ```
+
+3. Restart the Docker systemd service with the following commands:
+
+   ```bash
+   $ sudo systemctl daemon-reload
+   $ sudo systemctl restart docker
+   ```
+
+4. Run Kata Containers
+
+   You are now ready to run Kata Containers:
+
+   ```bash
+   $ sudo docker run -ti busybox uname -a
+   ```
+
+   The previous command shows details of the kernel version running inside the
+   container, which is different to the host kernel version.

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -2,7 +2,8 @@
 
 > **Notes:**
 >
-> - Kata Containers packages are available for Fedora\* versions **26** and **27** (currently `x86_64` only).
+> - Kata Containers packages are available for [Fedora\*](https://fedoraproject.org)
+>   versions **26** and **27** (currently `x86_64` only).
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -8,55 +8,26 @@
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
 >
-> - This install guide is specific to integration with Docker.  If you want to use Kata
->   Containers through Kubernetes, see the "Developer Guide" [here](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes).
+> - If you do not want to copy or type all these instructions by hand, you can use the
+>   [`kata-manager`](https://github.com/kata-containers/tests/blob/master/cmd/kata-manager/kata-manager.sh)
+>   script to install the packaged system including your chosen container
+>   manager. Alternatively, you can generate a runnable shell script from
+>   individual documents using the
+>   [`kata-doc-to-script`](https://github.com/kata-containers/tests/blob/master/.ci/kata-doc-to-script.sh) script.
 
-This step is only required in case Docker is not installed on the system.
-1. Install the latest version of Docker with the following commands:
+1. Install the Kata Containers components with the following commands:
 
-```bash
-$ sudo dnf -y install dnf-plugins-core
-$ sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
-$ sudo dnf makecache
-$ sudo dnf -y install docker-ce
-```
+   > **Note:** This installation channel is not secure since the repository currently
+   > redirects download URLs to `http`.
 
-For more information on installing Docker please refer to the
-[Docker Guide](https://docs.docker.com/engine/installation/linux/fedora)
+   ```bash
+   $ source /etc/os-release
+   $ sudo dnf -y install dnf-plugins-core
+   $ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo http://download.opensuse.org/repositories/home:/katacontainers:/release/Fedora\_$VERSION_ID/home:katacontainers:release.repo
+   $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
+   ```
 
-2. Install the Kata Containers components with the following commands:
+2. Decide which container manager you will use and select the corresponding link that follows:
 
-> **Note:** The repository redirects the download content to use `http`, be aware that this installation channel is not secure.
-
-```bash
-$ source /etc/os-release
-$ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo \
-http://download.opensuse.org/repositories/home:/katacontainers:/release/Fedora\_$VERSION_ID/home:katacontainers:release.repo
-$ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
-```
-
-3. Configure Docker to use Kata Containers by default with the following commands:
-
-```bash
-$ sudo mkdir -p /etc/systemd/system/docker.service.d/
-$ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
-[Service]
-ExecStart=
-ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
-EOF
-```
-
-4. Restart the Docker systemd service with the following commands:
-
-```bash
-$ sudo systemctl daemon-reload
-$ sudo systemctl restart docker
-```
-
-5. Run Kata Containers
-
-You are now ready to run Kata Containers:
-
-```
-$ sudo docker run -ti busybox sh
-```
+   - [Docker](docker/fedora-docker-install.md)
+   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes)

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -2,7 +2,8 @@
 
 > **Notes:**
 >
-> - Kata Containers packages are available for Ubuntu\* **16.04** and **17.10** (currently `x86_64` only).
+> - Kata Containers packages are available for [Ubuntu\*](https://www.ubuntu.com)
+>   versions **16.04** and **17.10** (currently `x86_64` only).
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -8,57 +8,26 @@
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
 >
-> - This install guide is specific to integration with Docker.  If you want to use Kata
->   Containers through Kubernetes, see the "Developer Guide" [here](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes).
+> - If you do not want to copy or type all these instructions by hand, you can use the
+>   [`kata-manager`](https://github.com/kata-containers/tests/blob/master/cmd/kata-manager/kata-manager.sh)
+>   script to install the packaged system including your chosen container
+>   manager. Alternatively, you can generate a runnable shell script from
+>   individual documents using the
+>   [`kata-doc-to-script`](https://github.com/kata-containers/tests/blob/master/.ci/kata-doc-to-script.sh) script.
 
-This step is only required in case Docker is not installed on the system.
-1. Install the latest version of Docker with the following commands:
+1. Install the Kata Containers components with the following commands:
 
-```bash
-$ sudo -E apt-get -y install apt-transport-https ca-certificates wget software-properties-common
-$ curl -sL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-$ arch=$(dpkg --print-architecture)
-$ sudo -E add-apt-repository "deb [arch=${arch}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-$ sudo -E apt-get update
-$ sudo -E apt-get -y install docker-ce
-```
+   > **Note:** This installation channel is not secure since the repository currently
+   > redirects download URLs to `http`.
 
-For more information on installing Docker please refer to the
-[Docker Guide](https://docs.docker.com/engine/installation/linux/ubuntu)
+   ```bash
+   $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
+   $ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
+   $ sudo -E apt-get update
+   $ sudo -E apt-get -y install kata-runtime kata-proxy kata-shim
+   ```
 
-2. Install the Kata Containers components with the following commands:
+2. Decide which container manager you will use and select the corresponding link that follows:
 
-> **Note:** The repository is downloading content using `http`, be aware that this installation channel is not secure.
-
-```bash
-$ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
-$ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
-$ sudo -E apt-get update
-$ sudo -E apt-get -y install kata-runtime kata-proxy kata-shim
-```
-
-3. Configure Docker to use Kata Containers by default with the following commands:
-
-```bash
-$ sudo mkdir -p /etc/systemd/system/docker.service.d/
-$ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
-[Service]
-ExecStart=
-ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
-EOF
-```
-
-4. Restart the Docker systemd service with the following commands:
-
-```bash
-$ sudo systemctl daemon-reload
-$ sudo systemctl restart docker
-```
-
-5. Run Kata Containers
-
-You are now ready to run Kata Containers:
-
-```
-$ sudo docker run -ti busybox sh
-```
+   - [Docker](docker/ubuntu-docker-install.md)
+   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes)


### PR DESCRIPTION
The install guides assumed that users wanted to install Docker. Since there are other container managers, split the Docker-specific instructions into separate documents (with backlinks) and allow the user to choose between Docker or Kubernetes from the install guides.

Also, ensure the first mention of all the distro names in the install guides:

- Have the required asterisk after the name.
- Have a link to the website.

Fixes #144.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
