### PR TITLE
docs: Adds hardware requirements to Install Guide

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -1,5 +1,8 @@
 # Kata Containers installation user guides
 
+Kata Containers requires nested virtualization or bare metal. 
+See the [hardware requirements](https://github.com/kata-containers/runtime/blob/master/README.md#hardware-requirements) to see if your system is capable of running Kata Containers.
+
 Select your preferred distribution:
 
 * [CentOS](https://github.com/kata-containers/documentation/blob/master/install/centos-installation-guide.md)


### PR DESCRIPTION
Puts the nested virt/bare metal requirement in the top line
of the Install Guide and references the Kata hardware
check.

Signed-off-by: Anne Bertucio <anne@openstack.org>