### PR TITLE
docs: Make "Install guest kernel images" arch-sensitive

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -265,10 +265,13 @@ As a prerequisite, you need to install `libelf-dev` and `bc`. Otherwise, you
 will not be able to build the kernel from sources.
 
 ```
-$ kernel_arch="$(arch)"
+$ go get github.com/kata-containers/tests
+$ cd $GOPATH/src/github.com/kata-containers/tests/.ci
+$ kernel_arch="$(./kata-arch.sh --golang)"
+$ kernel_dir="$(./kata-arch.sh --kernel)"
 $ tmpdir="$(mktemp -d)"
 $ pushd "$tmpdir"
-$ curl -L https://raw.githubusercontent.com/kata-containers/packaging/master/kernel/configs/x86_kata_kvm_4.14.x -o .config
+$ curl -L https://raw.githubusercontent.com/kata-containers/packaging/master/kernel/configs/${kernel_arch}_kata_kvm_4.14.x -o .config
 $ kernel_version=$(grep "Linux/[${kernel_arch}]*" .config | cut -d' ' -f3 | tail -1)
 $ kernel_tar_file="linux-${kernel_version}.tar.xz"
 $ kernel_url="https://cdn.kernel.org/pub/linux/kernel/v$(echo $kernel_version | cut -f1 -d.).x/${kernel_tar_file}"
@@ -277,10 +280,11 @@ $ tar -xf ${kernel_tar_file}
 $ mv .config "linux-${kernel_version}"
 $ pushd "linux-${kernel_version}"
 $ curl -L https://raw.githubusercontent.com/kata-containers/packaging/master/kernel/patches/0001-NO-UPSTREAM-9P-always-use-cached-inode-to-fill-in-v9.patch | patch -p1
-$ make ARCH=${kernel_arch} -j$(nproc)
+$ make ARCH=${kernel_dir} -j$(nproc)
 $ kata_kernel_dir="/usr/share/kata-containers"
 $ kata_vmlinuz="${kata_kernel_dir}/kata-vmlinuz-${kernel_version}.container"
-$ sudo install -o root -g root -m 0755 -D "$(realpath arch/${kernel_arch}/boot/bzImage)" "${kata_vmlinuz}"
+$ [ $kernel_arch = ppc64le ] && kernel_file="$(realpath ./vmlinux)" || kernel_file="$(realpath arch/${kernel_arch}/boot/bzImage)"
+$ sudo install -o root -g root -m 0755 -D "${kernel_file}" "${kata_vmlinuz}"
 $ sudo ln -sf "${kata_vmlinuz}" "${kata_kernel_dir}/vmlinuz.container"
 $ kata_vmlinux="${kata_kernel_dir}/kata-vmlinux-${kernel_version}"
 $ sudo install -o root -g root -m 0755 -D "$(realpath vmlinux)" "${kata_vmlinux}"


### PR DESCRIPTION
Make "Install guest kernel images" in Developer-Guide
arch specific.

Fixes: #140

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>