### PR TITLE
 developer-guide: use the correct kernel config file name

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -267,7 +267,7 @@ will not be able to build the kernel from sources.
 ```
 $ go get github.com/kata-containers/tests
 $ cd $GOPATH/src/github.com/kata-containers/tests/.ci
-$ kernel_arch="$(./kata-arch.sh --golang)"
+$ kernel_arch="$(./kata-arch.sh)"
 $ kernel_dir="$(./kata-arch.sh --kernel)"
 $ tmpdir="$(mktemp -d)"
 $ pushd "$tmpdir"


### PR DESCRIPTION
kernel_arch was being set to amd64 instead of x86_64
on intel. The kernel config file name starts with
x86_64 and hence this needs to be fixed.

Fixes:  #158

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>