### PR TITLE
GCE tweaks

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -5,13 +5,13 @@ See the [hardware requirements](https://github.com/kata-containers/runtime/blob/
 
 Select your preferred distribution:
 
-* [CentOS](https://github.com/kata-containers/documentation/blob/master/install/centos-installation-guide.md)
-* [Fedora](https://github.com/kata-containers/documentation/blob/master/install/fedora-installation-guide.md)
-* [Red Hat](https://github.com/kata-containers/documentation/blob/master/install/rhel-installation-guide.md)
-* [Ubuntu](https://github.com/kata-containers/documentation/blob/master/install/ubuntu-installation-guide.md) 
+* [CentOS](centos-installation-guide.md)
+* [Fedora](fedora-installation-guide.md)
+* [Red Hat](rhel-installation-guide.md)
+* [Ubuntu](ubuntu-installation-guide.md)
 
 For further information, see:
 
 * The [the upgrading document](../Upgrading.md).
-* The [developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md).
+* The [developer guide](../Developer-Guide.md).
 * The [runtime documentation](https://github.com/kata-containers/runtime/blob/master/README.md).

--- a/install/README.md
+++ b/install/README.md
@@ -1,16 +1,34 @@
 # Kata Containers installation user guides
 
-Kata Containers requires nested virtualization or bare metal. 
-See the [hardware requirements](https://github.com/kata-containers/runtime/blob/master/README.md#hardware-requirements) to see if your system is capable of running Kata Containers.
+* [Prerequisites](#prerequisites)
+* [Installing Kata Containers](#installing-kata-containers)
+    * [Distros](#distros)
+    * [Cloud services](#cloud-services)
+* [Further information](#further-information)
 
-Select your preferred distribution:
+## Prerequisites
+
+Kata Containers requires nested virtualization or bare metal. 
+See the
+[hardware requirements](https://github.com/kata-containers/runtime/blob/master/README.md#hardware-requirements)
+to see if your system is capable of running Kata Containers.
+
+## Installing Kata Containers
+
+Select your preferred distribution or cloud service:
+
+### Distros
 
 * [CentOS](centos-installation-guide.md)
 * [Fedora](fedora-installation-guide.md)
 * [Red Hat](rhel-installation-guide.md)
 * [Ubuntu](ubuntu-installation-guide.md)
 
-For further information, see:
+### Cloud services
+
+* [Google Compute Engine (GCE)](gce-installation-guide.md)
+
+## Further information
 
 * The [the upgrading document](../Upgrading.md).
 * The [developer guide](../Developer-Guide.md).

--- a/install/README.md
+++ b/install/README.md
@@ -30,6 +30,6 @@ Select your preferred distribution or cloud service:
 
 ## Further information
 
-* The [the upgrading document](../Upgrading.md).
+* The [upgrading document](../Upgrading.md).
 * The [developer guide](../Developer-Guide.md).
 * The [runtime documentation](https://github.com/kata-containers/runtime/blob/master/README.md).

--- a/install/gce-installation-guide.md
+++ b/install/gce-installation-guide.md
@@ -1,5 +1,11 @@
 # Install Kata Containers on Google Compute Engine
 
+* [Create an Image with Nested Virtualization Enabled](#create-an-image-with-nested-virtualization-enabled)
+    * [Create the Image](#create-the-image)
+    * [Verify VMX is Available](#verify-vmx-is-available)
+* [Install Kata](#install-kata)
+* [Create a Kata-enabled Image](#create-a-kata-enabled-image)
+
 Kata Containers on Google Compute Engine (GCE) makes use of [nested virtualization](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances). Most of the installation procedure is identical to that for Kata on your preferred distribution, but enabling nested virtualization currently requires extra steps on GCE. This guide walks you through creating an image and instance with nested virtualization enabled. Note that `kata-runtime kata-check` checks for nested virtualization, but does not fail if support is not found.
 
 As a pre-requisite this guide assumes an installed and configured instance of the [Google Cloud SDK](https://cloud.google.com/sdk/downloads). For a zero-configuration option, all of the commands below were been tested under [Google Cloud Shell](https://cloud.google.com/shell/) (as of Jun 2018). Verify your `gcloud` installation and configuration:


### PR DESCRIPTION
Add the new Google Compute Engine installation guide to the installation README.

Also,

- Add a table of contents to the Google Compute Engine install guide.
- Simplify the installation README by using relative URLs - let github expand them automatically for readers.

Fixes #173.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
