### PR TITLE
docs: Remove "-ti" from docker invocations

### DIFF
--- a/.ci/test-install-docs.sh
+++ b/.ci/test-install-docs.sh
@@ -12,14 +12,12 @@ info()
 	echo "INFO: $msg"
 }
 
-# Detect if any installation guides changed. If so, run the
+# Detect if any installation documents changed. If so, run the
 # kata manager to "execute" the install guide to ensure the
 # commands it specified result in a working system.
 check_install_guides()
 {
 	[ -n "$TRAVIS" ] && info "Not testing install guide as Travis lacks modern distro support and VT-x" && return 
-
-	local -r install_guide_suffix="-installation-guide.md"
 
 	# List of filters used to restrict the types of file changes.
 	# See git-diff-tree(1) for further info.
@@ -52,7 +50,7 @@ check_install_guides()
 	# No files were changed
 	[ -z "$files" ] && return
 
-	changed=$(echo "$files" | grep "install/.*${install_guide_suffix}$" || true)
+	changed=$(echo "$files" | grep "^install/.*\.md$" || true)
 
 	[ -z "$changed" ] && info "No install guides modified" && return
 

--- a/install/docker/centos-docker-install.md
+++ b/install/docker/centos-docker-install.md
@@ -47,7 +47,7 @@
    You are now ready to run Kata Containers:
 
    ```bash
-   $ sudo docker run -ti busybox uname -a
+   $ sudo docker run busybox uname -a
    ```
 
    The previous command shows details of the kernel version running inside the

--- a/install/docker/fedora-docker-install.md
+++ b/install/docker/fedora-docker-install.md
@@ -48,7 +48,7 @@
    You are now ready to run Kata Containers:
 
    ```bash
-   $ sudo docker run -ti busybox uname -a
+   $ sudo docker run busybox uname -a
    ```
 
    The previous command shows details of the kernel version running inside the

--- a/install/docker/rhel-docker-install.md
+++ b/install/docker/rhel-docker-install.md
@@ -48,7 +48,7 @@
    You are now ready to run Kata Containers:
 
    ```bash
-   $ sudo docker run -ti busybox uname -a
+   $ sudo docker run busybox uname -a
    ```
 
    The previous command shows details of the kernel version running inside the

--- a/install/docker/ubuntu-docker-install.md
+++ b/install/docker/ubuntu-docker-install.md
@@ -51,7 +51,7 @@
    You are now ready to run Kata Containers:
 
    ```bash
-   $ sudo docker run -ti busybox uname -a
+   $ sudo docker run busybox uname -a
    ```
 
    The previous command shows details of the kernel version running inside the


### PR DESCRIPTION
The docker install guides end with a call to `docker run`. However, they
all specify `-ti` which is causing our CI to fail.

Remove the `-ti` so that the command works both under the CI and as
expected for the user.

Fixes #175.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>