### PR TITLE
CI: update static-checks.sh call

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -21,5 +21,5 @@ clone_tests_repo()
 run_static_checks()
 {
 	clone_tests_repo
-	bash "$tests_repo_dir/.ci/static-checks.sh"
+	bash "$tests_repo_dir/.ci/static-checks.sh" "github.com/kata-containers/documentation"
 }


### PR DESCRIPTION
Now static-checks.sh needs to have the
repository name as arguments.

Fixes #179.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>