### PR TITLE
Document compatibility of component versions

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -2,6 +2,7 @@
 * [Assumptions](#assumptions)
 * [Initial setup](#initial-setup)
 * [Requirements to build individual components](#requirements-to-build-individual-components)
+* [Individual component compatibility](#individual-component-compatibility)
 * [Build and install the Kata Containers runtime](#build-and-install-the-kata-containers-runtime)
     * [Check hardware requirements](#check-hardware-requirements)
     * [Configure to use initrd or rootfs image](#configure-to-use-initrd-or-rootfs-image)
@@ -74,6 +75,22 @@ You need to install the following to build Kata Containers components:
 
 - `make`.
 - `gcc` (required for building the shim and runtime).
+
+# Individual component compatibility
+
+Using versions of individual components newer than the last official released
+version might result in
+[compatibility issues](Releases.md#component-version-compatibility).
+
+If you have only updated a subset of the Kata components and notice strange
+behavior, we recommend you update the remaining components to ensure you are
+using the latest versions of all of them. Also, remember to
+[create a new image containing the latest agent version](#create-and-install-rootfs-and-initrd-image).
+
+If you still have compatibility issues after following the previous
+instructions, refer to the
+[troubleshooting section](#troubleshoot-kata-containers) and
+[get in contact with us](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md#contact).
 
 # Build and install the Kata Containers runtime
 

--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -1,3 +1,5 @@
+# Kata Containers Developer Guide
+
 * [Warning](#warning)
 * [Assumptions](#assumptions)
 * [Initial setup](#initial-setup)

--- a/Releases.md
+++ b/Releases.md
@@ -37,7 +37,10 @@ Semantic versioning is used since the version number is able to convey clear inf
 
 ## Components
 
-A new release will result in all Kata components being given a new [version](#versioning), even if no changes were made to that component since the last version. The version for a release is **identical** for all  components.
+A new release results in all Kata components being given a new
+[version](#versioning), even if there are no changes to that component since
+the last version. The version for a release is **identical** for all
+components.
 
 This strategy allows diagnostic tools such as `kata-runtime kata-env` to record full version details of all components to help with problem determination.
 

--- a/Releases.md
+++ b/Releases.md
@@ -1,7 +1,7 @@
 * [Introduction](#introduction)
 * [Versioning](#versioning)
-* [Tagging repositories](#tagging-repositories)
 * [Components](#components)
+* [Tagging repositories](#tagging-repositories)
 * [Release checklist](#release-checklist)
 * [Release process](#release-process)
 
@@ -34,6 +34,14 @@ Semantic versioning is used since the version number is able to convey clear inf
 
   A major release will also likely require a change of the container manager version used, for example Docker\*. Please refer to the release notes for further details.
 
+## Components
+
+A new release will result in all Kata components being given a new [version](#versioning), even if no changes were made to that component since the last version. The version for a release is **identical** for all  components.
+
+This strategy allows diagnostic tools such as `kata-runtime kata-env` to record full version details of all components to help with problem determination.
+
+Note that although hypervisor and guest kernel both have versions, these are not updated for new releases as they are not core components developed by the Kata community.
+
 ## Tagging repositories
 
 To create a signed and annotated tag for a repository, first ensure that `git(1)` is configured to use your `gpg(1)` key:
@@ -54,14 +62,6 @@ The annotation text must conform to the usual [patch format rules](https://githu
 
 - The subsystem must be "`release: $tag`".
 - The body of the message must contain details of changes in the release in `git-shortlog(1)` format.
-
-## Components
-
-A new release will result in all Kata components being given a new [version](#versioning), even if no changes were made to that component since the last version. The version for a release is **identical** for all  components.
-
-This strategy allows diagnostic tools such as `kata-runtime kata-env` to record full version details of all components to help with problem determination.
-
-Note that although hypervisor and guest kernel both have versions, these are not updated for new releases as they are not core components developed by the Kata community.
 
 ## Release checklist
 

--- a/Releases.md
+++ b/Releases.md
@@ -1,6 +1,7 @@
 * [Introduction](#introduction)
 * [Versioning](#versioning)
 * [Components](#components)
+    * [Component version compatibility](#component-version-compatibility)
 * [Tagging repositories](#tagging-repositories)
 * [Release checklist](#release-checklist)
 * [Release process](#release-process)
@@ -41,6 +42,16 @@ A new release will result in all Kata components being given a new [version](#ve
 This strategy allows diagnostic tools such as `kata-runtime kata-env` to record full version details of all components to help with problem determination.
 
 Note that although hypervisor and guest kernel both have versions, these are not updated for new releases as they are not core components developed by the Kata community.
+
+### Component version compatibility
+
+Semantic versioning allows users to determine how a new version of a
+particular component relates to the previous version of that component.
+However, it is not possible to compare two *different* Kata component
+versions, even though all component versions are changed together.
+
+To ensure compatibility it is necessary to always use components of the same
+version.
 
 ## Tagging repositories
 

--- a/Upgrading.md
+++ b/Upgrading.md
@@ -134,7 +134,8 @@ As shown in the
 [installation instructions](https://github.com/kata-containers/documentation/blob/master/install),
 Kata Containers provide binaries for popular distributions in their native
 packaging formats. This allows Kata Containers to be upgraded using the
-standard package management tools for your distribution.
+standard package management tools for your distribution and also guarantees
+[component version compatibility](Releases.md#component-version-compatibility).
 
 # Appendices
 


### PR DESCRIPTION
Add new "Component version compatibility" section to the Releases document that explains all component versions must match.

Also, update the developer guide and upgrading document to refer to the "Component version compatibility" section of the Releases doc.

Fixes #177.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>