### PR TITLE
docs: update kube anchor in distro install guides

### DIFF
--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -30,4 +30,4 @@
 2. Decide which container manager to use and select the corresponding link that follows:
 
    - [Docker](docker/centos-docker-install.md)
-   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes)
+   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#run-kata-containers-with-kubernetes)

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -30,4 +30,4 @@
 2. Decide which container manager to use and select the corresponding link that follows:
 
    - [Docker](docker/fedora-docker-install.md)
-   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes)
+   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#run-kata-containers-with-kubernetes)

--- a/install/rhel-installation-guide.md
+++ b/install/rhel-installation-guide.md
@@ -29,4 +29,4 @@
 2. Decide which container manager to use and select the corresponding link that follows:
 
    - [Docker](docker/rhel-docker-install.md)
-   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes)
+   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#run-kata-containers-with-kubernetes)

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -30,4 +30,4 @@
 2. Decide which container manager to use and select the corresponding link that follows:
 
    - [Docker](docker/ubuntu-docker-install.md)
-   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#if-you-want-to-run-kata-containers-with-kubernetes)
+   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#run-kata-containers-with-kubernetes)


### PR DESCRIPTION
The anchor changed for Kube get started instructions. Updated the installation guides to correct the developer guide links.

Fixes https://github.com/kata-containers/documentation/issues/184