### PR TITLE
docs: Add initcall_debug to dev guide debug section

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -134,7 +134,7 @@ Enable full debug as follows:
 
 ```
 $ sudo sed -i -e 's/^# *\(enable_debug\).*=.*$/\1 = true/g' /usr/share/defaults/kata-containers/configuration.toml
-$ sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' /usr/share/defaults/kata-containers/configuration.toml
+$ sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug initcall_debug"/g' /usr/share/defaults/kata-containers/configuration.toml
 ```
 
 ### journald rate limiting


### PR DESCRIPTION
https://github.com/kata-containers/runtime/pull/527 Removed the
hard-coded `initcall_debug` kernel option (as it generates a lot of
kernel output at boot).

Add the `initcall_debug` option to the "Enable full debug" section to
allow users to enable these potentially useful messages when debugging.

Fixes #204.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>