### PR TITLE
docs: Change install URLs to https

### DIFF
--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -17,13 +17,10 @@
 
 1. Install the Kata Containers components with the following commands:
 
-   > **Note:** This installation channel is not secure since the repository currently
-   > redirects download URLs to `http`.
-
    ```bash
    $ source /etc/os-release
    $ sudo yum -y install yum-utils
-   $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_${VERSION_ID}/home:katacontainers:release.repo"
+   $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "https://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_${VERSION_ID}/home:katacontainers:release.repo"
    $ sudo -E yum -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -17,13 +17,10 @@
 
 1. Install the Kata Containers components with the following commands:
 
-   > **Note:** This installation channel is not secure since the repository currently
-   > redirects download URLs to `http`.
-
    ```bash
    $ source /etc/os-release
    $ sudo dnf -y install dnf-plugins-core
-   $ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo http://download.opensuse.org/repositories/home:/katacontainers:/release/Fedora\_$VERSION_ID/home:katacontainers:release.repo
+   $ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo https://download.opensuse.org/repositories/home:/katacontainers:/release/Fedora\_$VERSION_ID/home:katacontainers:release.repo
    $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/rhel-installation-guide.md
+++ b/install/rhel-installation-guide.md
@@ -17,12 +17,9 @@
 
 1. Install the Kata Containers components with the following commands:
 
-   > **Note:** This installation channel is not secure since the repository currently
-   > redirects download URLs to `http`.
-
    ```bash
    $ source /etc/os-release
-   $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/release/RHEL_${VERSION_ID}/home:katacontainers:release.repo"
+   $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "https://download.opensuse.org/repositories/home:/katacontainers:/release/RHEL_${VERSION_ID}/home:katacontainers:release.repo"
    $ sudo -E yum -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -17,12 +17,9 @@
 
 1. Install the Kata Containers components with the following commands:
 
-   > **Note:** This installation channel is not secure since the repository currently
-   > redirects download URLs to `http`.
-
    ```bash
-   $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
-   $ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
+   $ sudo sh -c "echo 'deb https://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
+   $ curl -sL  https://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
    $ sudo -E apt-get update
    $ sudo -E apt-get -y install kata-runtime kata-proxy kata-shim
    ```


### PR DESCRIPTION
Now that the OBS server has enabled full https (no more redirecting to
http for the actual package downloads), remove the warning and switch to
specifying an https repository URL.

Fixes #212.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>