### PR TITLE
docs: Update install guide for fedora

### DIFF
--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -3,7 +3,7 @@
 > **Notes:**
 >
 > - Kata Containers packages are available for [Fedora\*](https://fedoraproject.org)
->   versions **26** and **27** (currently `x86_64` only).
+>   versions **27** and **28** (currently `x86_64` only).
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).


### PR DESCRIPTION
Update install documentation guide for fedora to include the
support for fedora 28.

Fixes #218

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>