### PR TITLE
docs: Remove support of ubuntu 17.10 on installation guide

### DIFF
--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -3,7 +3,7 @@
 > **Notes:**
 >
 > - Kata Containers packages are available for [Ubuntu\*](https://www.ubuntu.com)
->   versions **16.04**, **17.10** and **18.04** (currently `x86_64` only).
+>   versions **16.04** and **18.04** (currently `x86_64` only).
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).


### PR DESCRIPTION
Remove the support of ubuntu 17.10 as it is now end of life.

Fixes #223

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>