### PR TITLE
documentation:install: Fix a broken link

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -22,7 +22,7 @@ Select your preferred distribution or cloud service:
 * [CentOS](centos-installation-guide.md)
 * [Fedora](fedora-installation-guide.md)
 * [Red Hat](rhel-installation-guide.md)
-* [OpenSuse] (opensuse-installation-guide.md)
+* [OpenSuse](opensuse-installation-guide.md)
 * [Ubuntu](ubuntu-installation-guide.md)
 * [SLES](sles-installation-guide.md)
 


### PR DESCRIPTION
The "OpenSuse" link under "Installing Kata Containers"
is broken. Fix it.

Fixes: #228
Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com