### PR TITLE
docs: Don't hardcode minimum golang version

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -73,7 +73,7 @@ guest kernel.
 
 You need to install the following to build Kata Containers components:
 
-- [golang](https://golang.org/dl) version 1.8.3 or newer.
+- [golang](https://golang.org/dl)
 
   To view the versions of go known to work, see the `golang` entry in the
   [versions database](https://github.com/kata-containers/runtime/blob/master/versions.yaml).


### PR DESCRIPTION
The minimum golang version should be defined *once* - in [1]. Since the
developer guide already provides a link to that human-readable file,
remove the hard-coded golang version number to avoid having to maintain
that part of the devguide.

Fixes #232.

[1] - https://github.com/kata-containers/runtime/blob/master/versions.yaml

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>