### PR TITLE
install: have URLs point to the latest version on OBS

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -8,14 +8,23 @@
 
 ## Prerequisites
 
-Kata Containers requires nested virtualization or bare metal. 
+Kata Containers requires nested virtualization or bare metal.
 See the
 [hardware requirements](https://github.com/kata-containers/runtime/blob/master/README.md#hardware-requirements)
 to see if your system is capable of running Kata Containers.
 
 ## Installing Kata Containers
 
-Select your preferred distribution or cloud service:
+> **Notes:**
+> - [This download server](http://download.opensuse.org/repositories/home:/katacontainers:/releases:/)
+> hosts the Kata Containers packages built by OBS for all the supported architectures.
+> Packages are available for the latest and stable releases (more info [here](https://github.com/kata-containers/documentation/blob/master/Stable-Branch-Strategy.md)).
+>
+> - The following guides apply to the latest Kata Containers release
+> (a.k.a. `master` release).
+>
+> - When choosing a stable release, replace all `master` occurrences in the URLs
+> with a `stable-x.y` version available on the [download server](http://download.opensuse.org/repositories/home:/katacontainers:/releases:/).
 
 ### Distros
 

--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -3,7 +3,7 @@
 > **Notes:**
 >
 > - Kata Containers packages are available for [CentOS\*](https://www.centos.org)
->   version 7 (currently `x86_64` only).
+>   version 7.
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
@@ -23,7 +23,8 @@
    ```bash
    $ source /etc/os-release
    $ sudo yum -y install yum-utils
-   $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_${VERSION_ID}/home:katacontainers:release.repo"
+   $ ARCH=$(arch)
+   $ sudo -E yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/CentOS_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E yum -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -3,7 +3,7 @@
 > **Notes:**
 >
 > - Kata Containers packages are available for [Fedora\*](https://fedoraproject.org)
->   versions **27** and **28** (currently `x86_64` only).
+>   versions **27** and **28**.
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
@@ -22,8 +22,9 @@
 
    ```bash
    $ source /etc/os-release
+   $ ARCH=$(arch)
    $ sudo dnf -y install dnf-plugins-core
-   $ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo http://download.opensuse.org/repositories/home:/katacontainers:/release/Fedora\_$VERSION_ID/home:katacontainers:release.repo
+   $ sudo -E dnf config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/Fedora_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/opensuse-installation-guide.md
+++ b/install/opensuse-installation-guide.md
@@ -3,7 +3,7 @@
 > **Notes:**
 >
 > - Kata Containers packages are available for [openSUSE\*](https://www.opensuse.org/)
->   version 43.2 (currently `x86_64` only).
+>   version 43.2.
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
@@ -22,7 +22,8 @@
 
    ```bash
    $ source /etc/os-release
-   $ sudo -E VERSION_ID=$VERSION_ID zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/release/openSUSE_Leap_${VERSION_ID}/home:katacontainers:release.repo"
+   $ ARCH=$(arch)
+   $ sudo -E zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/openSUSE_Leap_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E zypper -n --no-gpg-checks install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/rhel-installation-guide.md
+++ b/install/rhel-installation-guide.md
@@ -3,7 +3,7 @@
 > **Notes:**
 >
 > - Kata Containers packages are available for [RHEL\*](https://www.redhat.com)
->   version 7 (currently `x86_64` only).
+>   version 7.
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
@@ -22,7 +22,8 @@
 
    ```bash
    $ source /etc/os-release
-   $ sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/release/RHEL_${VERSION_ID}/home:katacontainers:release.repo"
+   $ ARCH=$(arch)
+   $ sudo -E yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/RHEL_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E yum -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/sles-installation-guide.md
+++ b/install/sles-installation-guide.md
@@ -3,7 +3,7 @@
 > **Notes:**
 >
 > - Kata Containers packages are available for [openSUSE\*](https://www.opensuse.org/)
->   version 43.2 (currently `x86_64` only).
+>   version 43.2.
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
@@ -21,7 +21,8 @@
    > redirects download URLs to `http`.
 
    ```bash
-   $ sudo -E zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/release/SLE_12_SP3/home:katacontainers:release.repo"
+   $ ARCH=$(arch)
+   $ sudo -E zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/SLE_12_SP3/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E zypper -n --no-gpg-checks install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -3,7 +3,7 @@
 > **Notes:**
 >
 > - Kata Containers packages are available for [Ubuntu\*](https://www.ubuntu.com)
->   versions **16.04** and **18.04** (currently `x86_64` only).
+>   versions **16.04** and **18.04**.
 >
 > - If you are installing on a system that already has Clear Containers or `runv` installed,
 >   first read [the upgrading document](../Upgrading.md).
@@ -21,8 +21,9 @@
    > redirects download URLs to `http`.
 
    ```bash
-   $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
-   $ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
+   $ ARCH=$(arch)
+   $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
+   $ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
    $ sudo -E apt-get update
    $ sudo -E apt-get -y install kata-runtime kata-proxy kata-shim
    ```


### PR DESCRIPTION
The repository URLs in the installation guides needs to point to the
latest release version.
This impact tests execution too (kata-manager uses this guides as
installation recipes).

Fixes: #255