### PR TITLE
CI: Pin Travis golang version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@
 sudo: required
 dist: trusty
 
-language: bash
+language: go
+
+go:
+  - "1.10.x"
 
 before_script:
   - ".ci/setup.sh"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+default:
+	@true


### PR DESCRIPTION
Travis appears to be providing a version of golang that is too old for
https://mvdan.cc/xurls/cmd/xurls, which is used by the CI scripts in the
tests repo.

See:

- https://github.com/kata-containers/runtime/pull/744
- https://github.com/kata-containers/tests/pull/843#issuecomment-432297737

Fixes #281.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>