### PR TITLE
Use https instead of http in package installs

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -54,7 +54,7 @@ Manual installation instructions are available for [these distributions](#suppor
 >  first read [the upgrading document](../Upgrading.md).
 
 > **Notes on releases**:
-> - [This download server](http://download.opensuse.org/repositories/home:/katacontainers:/releases:/)
+> - [This download server](https://download.opensuse.org/repositories/home:/katacontainers:/releases:/)
 > hosts the Kata Containers packages built by OBS for all the supported architectures.
 > Packages are available for the latest and stable releases (more info [here](https://github.com/kata-containers/documentation/blob/master/Stable-Branch-Strategy.md)).
 >
@@ -62,7 +62,7 @@ Manual installation instructions are available for [these distributions](#suppor
 > (a.k.a. `master` release).
 >
 > - When choosing a stable release, replace all `master` occurrences in the URLs
-> with a `stable-x.y` version available on the [download server](http://download.opensuse.org/repositories/home:/katacontainers:/releases:/).
+> with a `stable-x.y` version available on the [download server](https://download.opensuse.org/repositories/home:/katacontainers:/releases:/).
 
 > **Notes on packages source verification**:
 > - The Kata packages hosted on the download server are signed with GPG to ensure integrity and authenticity.

--- a/install/centos-installation-guide.md
+++ b/install/centos-installation-guide.md
@@ -6,7 +6,7 @@
    $ source /etc/os-release
    $ sudo yum -y install yum-utils
    $ ARCH=$(arch)
-   $ sudo -E yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/CentOS_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
+   $ sudo -E yum-config-manager --add-repo "https://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/CentOS_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E yum -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -6,7 +6,7 @@
    $ source /etc/os-release
    $ ARCH=$(arch)
    $ sudo dnf -y install dnf-plugins-core
-   $ sudo -E dnf config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/Fedora_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
+   $ sudo -E dnf config-manager --add-repo "https://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/Fedora_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/opensuse-installation-guide.md
+++ b/install/opensuse-installation-guide.md
@@ -5,7 +5,7 @@
    ```bash
    $ source /etc/os-release
    $ ARCH=$(arch)
-   $ sudo -E zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/openSUSE_Leap_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
+   $ sudo -E zypper addrepo "https://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/openSUSE_Leap_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E zypper -n --no-gpg-checks install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/rhel-installation-guide.md
+++ b/install/rhel-installation-guide.md
@@ -5,7 +5,7 @@
    ```bash
    $ source /etc/os-release
    $ ARCH=$(arch)
-   $ sudo -E yum-config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/RHEL_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
+   $ sudo -E yum-config-manager --add-repo "https://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/RHEL_${VERSION_ID}/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E yum -y install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/sles-installation-guide.md
+++ b/install/sles-installation-guide.md
@@ -4,7 +4,7 @@
 
    ```bash
    $ ARCH=$(arch)
-   $ sudo -E zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/SLE_12_SP3/home:katacontainers:releases:${ARCH}:master.repo"
+   $ sudo -E zypper addrepo "https://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/SLE_12_SP3/home:katacontainers:releases:${ARCH}:master.repo"
    $ sudo -E zypper -n --no-gpg-checks install kata-runtime kata-proxy kata-shim
    ```
 

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -4,8 +4,8 @@
 
    ```bash
    $ ARCH=$(arch)
-   $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
-   $ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
+   $ sudo sh -c "echo 'deb https://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
+   $ curl -sL  https://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
    $ sudo -E apt-get update
    $ sudo -E apt-get -y install kata-runtime kata-proxy kata-shim
    ```

--- a/zun/zun_kata.md
+++ b/zun/zun_kata.md
@@ -53,7 +53,7 @@ zun delete test
 ## Install `kata-runtime`, `kata-shim`, and `kata-proxy`
 
 ```
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' >> /etc/apt/sources.list.d/kata-containers.list"
+sudo sh -c "echo 'deb https://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' >> /etc/apt/sources.list.d/kata-containers.list"
 curl -sL  https://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
 sudo -E apt-get update
 sudo -E apt-get -y install kata-runtime kata-proxy kata-shim


### PR DESCRIPTION
Relying on bare HTTP to retrieve release keys or packages opens yourself to a variety of MITM attacks and root compromises.

I checked that download.opensuse.org is accessible using https://, so this should really be used instead.