### PR TITLE
Correct nginx example in developer docu

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -523,8 +523,8 @@ metadata:
     io.kubernetes.cri.untrusted-workload: "true"
 spec:
   containers:
-    name: nginx
-    image: nginx
+    - name: nginx
+      image: nginx
 ```
 
 Next, you run your pod:


### PR DESCRIPTION
Signed-off-by: Johannes M. Scheuermann <joh.scheuer@gmail.com>

Correct the example in the developer docu otherwise you will get the following error:

```bash
error: error validating "nginx-untrusted.yaml": error validating data: ValidationError(Pod.spec.containers): invalid type for io.k8s.api.core.v1.PodSpec.containers: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false

```