### PR TITLE
docs: Don't use backslashes in command blocks

### DIFF
--- a/Documentation-Requirements.md
+++ b/Documentation-Requirements.md
@@ -100,6 +100,14 @@ utility.
 
   ```
 
+- Long lines should not span across multiple lines by using the '`\`'
+  continuation character.
+
+  GitHub automatically renders such blocks with scrollbars. Consequently,
+  backslash continuation characters are not necessary and are a visual
+  distraction. These characters also mess up a user's shell history when
+  commands are pasted into a terminal.
+
 # Images
 
 All binary image files must be in a standard and well-supported format such as


### PR DESCRIPTION
Advise authors not to use continuation characters in code blocks.

Fixes #303.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>