### PR TITLE
Patch for debian install instructions docs

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -76,6 +76,7 @@ Manual installation instructions are available for [these distributions](#suppor
 |Distro specific installation instructions                          | Versions        |
 |-------------------------------------------------------------------|-----------------|
 |[CentOS](centos-installation-guide.md)                             | 7               |
+|[Debian](debian-installation-guide.md)                             | 9               |
 |[Fedora](fedora-installation-guide.md)                             | 27, 28          |
 |[openSUSE](opensuse-installation-guide.md)                         | Leap (42.3)     |
 |[Red Hat Enterprise Linux (RHEL)](rhel-installation-guide.md)      | 7               |

--- a/install/debian-installation-guide.md
+++ b/install/debian-installation-guide.md
@@ -1,0 +1,44 @@
+# Install Kata Containers on Debian
+
+1. Install the unsatisfied dependencies
+
+  Kata Containers packages depends on a version of `librdbd1` that's not yet available in the `stable` repo.
+  A more recent version of `librdbd1` can be installed from the `unstable` repo: https://packages.debian.org/sid/librbd1
+
+  Add `unstable` repo to `/etc/apt/sources.list.d/unstable.list` sources list:
+  
+  ```bash
+  $ sudo sh -c "echo '# for unstable packages
+  deb http://ftp.debian.org unstable main contrib non-free
+  deb-src http://ftp.debian.org unstable main contrib non-free' > /etc/apt/sources.list.d/unstable.list"
+  ```
+  
+  Set the repository to a lower priority than stable, to ensures that APT will prefer stable packages over unstable ones. This can be specified in `/etc/apt/preferences.d/unstable`:
+  
+  ```bash
+  $ sudo sh -c "echo 'Package: *
+  Pin: release a=unstable
+  Pin-Priority: 10' >> /etc/apt/preferences.d/unstable"
+  ```
+
+  Finally, install `librbd1`:
+
+  ```bash 
+  $ sudo apt-get update && sudo apt-get install -y -t unstable librbd1
+  ```
+
+2. Install the Kata Containers components with the following commands:
+
+   ```bash
+   $ ARCH=$(arch)
+   $ source /etc/os-release
+   $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/Debian_9/$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
+   $ curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/Debian_9/$(lsb_release -rs)/Release.key | sudo apt-key add -
+   $ sudo -E apt-get update
+   $ sudo -E apt-get -y install kata-runtime kata-proxy kata-shim
+   ```
+
+3. Decide which container manager to use and select the corresponding link that follows:
+
+   - [Docker](docker/ubuntu-docker-install.md)
+   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#run-kata-containers-with-kubernetes)

--- a/install/docker/debian-docker-install.md
+++ b/install/docker/debian-docker-install.md
@@ -1,0 +1,95 @@
+# Install Docker for Kata Containers on Debian
+
+> **Note:**
+>
+> - This guide assumes you have
+>   [already installed the Kata Containers packages](../debian-installation-guide.md).
+> - this guide allows for installation with `systemd` or `sysVinit` init systems
+
+1. Install the latest version of Docker with the following commands:
+
+   > **Note:** This step is only required if Docker is not installed on the system.
+
+   ```bash
+   $ sudo apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common  
+   $ curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | sudo apt-key add -
+   $ sudo add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
+   $ sudo apt-get update
+   $ sudo apt-get -y install docker-ce
+   ```
+
+   For more information on installing Docker please refer to the
+   [Docker Guide](https://docs.docker.com/engine/installation/linux/debian).
+
+2. Configure Docker to use Kata Containers by default with ONE of the following methods:
+
+a. sysVinit
+    
+    - with sysVinit,  docker config is stored in `/etc/default/docker`, edit the options similar to the following: 
+       
+    ```
+    $ sudo sh -c "echo '# specify docker runtime for kata-containers
+    DOCKER_OPTS=\"-D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime\"' >> /etc/default/docker"
+    ```
+    
+b. systemd
+
+    ```bash
+    $ sudo mkdir -p /etc/systemd/system/docker.service.d/
+    $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
+    [Service]
+    ExecStart=
+    ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+    EOF
+    ```
+
+c. systemd Docker `daemon.json`
+
+    Add the following definitions to `/etc/docker/daemon.json`:
+
+    ```bash
+    $ sudo sh -c "echo '{
+      \"default-runtime\": \"kata-runtime\",
+      \"runtimes\": {
+        \"kata-runtime\": {
+          \"path\": \"/usr/bin/kata-runtime\"
+        }
+      }
+    }' >> /etc/docker/daemon.json"
+    ```
+
+3. Restart the Docker systemd service with one of the following (depending on init choice):
+
+    a. sysVinit
+  
+    ```bash
+    $ sudo /etc/init.d/docker stop
+    $ sudo /etc/init.d/docker start
+    ```
+
+    to watch for errors:
+
+    ```bash
+    tail -f /var/log/docker.log
+    ```
+    
+    b. systemd
+
+    ```bash
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl restart docker
+    ```
+
+4. Run Kata Containers
+
+   You are now ready to run Kata Containers:
+
+   ```bash
+   $ sudo docker run busybox uname -a
+   ```
+
+   The previous command shows details of the kernel version running inside the
+   container, which is different to the host kernel version.
+
+   
+   


### PR DESCRIPTION
I have tested these install instructions in Debian 9.
Based on Ubuntu 17.10 packages with the main difference being that we need to pull `librdb1` from the unstable packages.