### PR TITLE
docs: Improve Developer-Guide and SRIOV doc on arm64

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -342,7 +342,8 @@ $ curl -L https://raw.githubusercontent.com/kata-containers/packaging/master/ker
 $ make ARCH=${kernel_dir} -j$(nproc)
 $ kata_kernel_dir="/usr/share/kata-containers"
 $ kata_vmlinuz="${kata_kernel_dir}/kata-vmlinuz-${kernel_version}.container"
-$ [ $kernel_arch = ppc64le ] && kernel_file="$(realpath ./vmlinux)" || kernel_file="$(realpath arch/${kernel_arch}/boot/bzImage)"
+$ case $kernel_arch in ppc64le) kernel_path="./vmlinux";; aarch64) kernel_path="arch/arm64/boot/Image";; *) kernel_path="arch/${kernel_arch}/boot/bzImage";; esac
+$ kernel_file="$(realpath $kernel_path)"
 $ sudo install -o root -g root -m 0755 -D "${kernel_file}" "${kata_vmlinuz}"
 $ sudo ln -sf "${kata_vmlinuz}" "${kata_kernel_dir}/vmlinuz.container"
 $ kata_vmlinux="${kata_kernel_dir}/kata-vmlinux-${kernel_version}"

--- a/use-cases/using-SRIOV-and-kata.md
+++ b/use-cases/using-SRIOV-and-kata.md
@@ -41,6 +41,9 @@ In order to setup your host for SR-IOV, the following has to be true:
   Controller (NIC). The section [Checking your NIC for SR-IOV](#checking-your-nic-for-sr-iov) describes how to assess if you need to make NIC changes and how to make
   the necessary changes.
 
+Besides, you need to enable the NIC driver in your guest kernel config (e.g. mlx5 for Mellanox NIC).
+All the modules need to be complied as built-in instead of loadable.
+
 ### Checking your NIC for SR-IOV
 
 The following is an example of how to use `lspci` to check if your NIC supports


### PR DESCRIPTION
This improves the guest kernel build section of Developer-Guide
on arm64.
This also improve the description of sriov use-case.

Fixes: #299
Signed-off-by: Jia He <justin.he@arm.com>