### PR TITLE
cloud: vexx: fix wrong style type of vexx title

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -85,7 +85,7 @@ Manual installation instructions are available for [these distributions](#suppor
 ## Installing on a Cloud Service Platform
 * [Amazon Web Services (AWS)](aws-installation-guide.md)
 * [Google Compute Engine (GCE)](gce-installation-guide.md)
-# [VEXXHOST OpenStack Cloud](vexxhost-installation-guide.md)
+* [VEXXHOST OpenStack Cloud](vexxhost-installation-guide.md)
 
 ## Further information
 * The [upgrading document](../Upgrading.md).


### PR DESCRIPTION
The vexx got added as a '#' top level item instead of a
'*' bullet entry. Fix it...

Fixes: #316

Signed-off-by: Graham Whaley <graham.whaley@intel.com>