### PR TITLE
Docs fix: ps is no more a limitation

### DIFF
--- a/Limitations.md
+++ b/Limitations.md
@@ -109,19 +109,6 @@ Note that the OCI standard does not specify an `events` command.
 
 See issue https://github.com/kata-containers/runtime/issues/308 and https://github.com/kata-containers/runtime/issues/309 for more information.
 
-### ps command
-
-The Kata Containers runtime does not currently support the `ps` command.
-
-Note that this is *not* the same as the `docker ps` command. The runtime `ps`
-command lists the processes running within a container. The `docker ps`
-command lists the containers themselves. The runtime `ps` command is
-invoked from `docker top`.
-
-Note that the OCI standard does not specify a `ps` command.
-
-See issue https://github.com/kata-containers/runtime/issues/129 for more information.
-
 ### update command
 
 Currently, only block I/O weight is not supported.


### PR DESCRIPTION
 The ps limitation was fixed by the the PR: https://github.com/kata-containers/runtime/pull/130