### PR TITLE
Docs: Remove invalid option from suse guides

### DIFF
--- a/install/docker/opensuse-docker-install.md
+++ b/install/docker/opensuse-docker-install.md
@@ -26,7 +26,7 @@
        $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
        [Service]
        ExecStart=
-       ExecStart=/usr/bin/dockerd -D --containerd /run/containerd/containerd.sock --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+       ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
        EOF
        ```
 

--- a/install/docker/sles-docker-install.md
+++ b/install/docker/sles-docker-install.md
@@ -25,7 +25,7 @@
        $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
        [Service]
        ExecStart=
-       ExecStart=/usr/bin/dockerd -D --containerd /run/containerd/containerd.sock --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+       ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
        EOF
        ```
 


### PR DESCRIPTION
The OpenSUSE and SLES install guide for Docker used the --containerd
option. When this option is used on OpenSUSE Leap 15 or SLES 15, the
following error occurs when starting Docker:

    Failed to connect to containerd: failed to dial
        "/run/containerd/containerd.sock": context deadline exceeded

Removing the --containerd option from the configuration file allows the
Docker daemon to start successfully and a Kata container to be created.

Signed-off-by: John L. Jolly <jjolly@suse.com>