### PR TITLE
install: snap: add link out to config and integrate instrs

### DIFF
--- a/install/snap-installation-guide.md
+++ b/install/snap-installation-guide.md
@@ -8,3 +8,6 @@ Run the following command to install Kata Containers:
    ```bash
    $ sudo snap install kata-containers --classic
    ```
+
+For further information on integrating and configuring the `snap` Kata Containers install,
+refer to the [Kata Containers packaging `snap` documentation](https://github.com/kata-containers/packaging/blob/master/snap/README.md#configure-kata-containers).


### PR DESCRIPTION
The snap install doc only told you how to install the kata snap,
and did not then go further to describe how to configure and
intergrate it. Those details are available already over in the
packaging repo, so let's link out to them.

Fixes: #360

Signed-off-by: Graham Whaley <graham.whaley@intel.com>