### PR TITLE
install: Make Debian install fully non-interactive

### DIFF
--- a/install/debian-installation-guide.md
+++ b/install/debian-installation-guide.md
@@ -30,6 +30,7 @@
 2. Install the Kata Containers components with the following commands:
 
    ```bash
+   $ export DEBIAN_FRONTEND=noninteractive
    $ ARCH=$(arch)
    $ source /etc/os-release
    $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/Debian_${VERSION_ID}/ /' > /etc/apt/sources.list.d/kata-containers.list"


### PR DESCRIPTION
Although the installation instructions specify `apt-get -y ...`, the
installation blocks when trying to install the Kata pages with a message
like this:

```
...

Restart services during package upgrades without asking?

<Yes>                                          <No>
```

Setting `DEBIAN_FRONTEND=noninteractive` avoids this.

Fixes #363.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>