### PR TITLE
docs: firecracker: add top level link off to fc wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For details of the other Kata Containers repositories, see the
 
 * HOWTO: [Kata Containers with k8s and cri-containerd](./how-to/how-to-use-k8s-with-cri-containerd-and-kata.md)
 * HOWTO: [OpenStack Zun with Kata Containers](zun/zun_kata.md)
+* HOWTO: [Kata Containers with Firecracker](https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support)
 
 ## Developer Guide
 


### PR DESCRIPTION
We have some initial Firecracker/Kata documentaiton, but for now
it lives in the wiki. Link off to it from the top level docs
README to make it more obvious and easier to find.

Fixes: #367

Signed-off-by: Graham Whaley <graham.whaley@intel.com>