### PR TITLE
zun: update kata install instructions

### DIFF
--- a/zun/zun_kata.md
+++ b/zun/zun_kata.md
@@ -50,14 +50,10 @@ zun logs test
 zun delete test
 ```
 
-## Install `kata-runtime`, `kata-shim`, and `kata-proxy`
+## Install Kata Containers
 
-```
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' >> /etc/apt/sources.list.d/kata-containers.list"
-curl -sL  https://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
-sudo -E apt-get update
-sudo -E apt-get -y install kata-runtime kata-proxy kata-shim
-```
+Follow [these instructions](https://github.com/kata-containers/documentation/blob/master/install/ubuntu-installation-guide.md)
+to install the Kata Containers components.
 
 ## Update Docker with new Kata Containers runtime
 


### PR DESCRIPTION
Update zun guide to point to the kata installation instructions for
Ubuntu.

Fixes: #371

Signed-off-by: Marco Vedovati <mvedovati@suse.com>