### PR TITLE
docs: Add RHEL and SLES install warnings

### DIFF
--- a/install/rhel-installation-guide.md
+++ b/install/rhel-installation-guide.md
@@ -1,5 +1,13 @@
 # Install Kata Containers on RHEL
 
+> **Warning:**
+>
+> - The RHEL packages are provided as a convenience to users until native
+>   packages are available in RHEL. However, they are **NOT** currently tested
+>   (although CentOS is) so caution should be exercised.
+>
+>   See https://github.com/kata-containers/ci/issues/3 for further details.
+
 1. Install the Kata Containers components with the following commands:
 
    ```bash

--- a/install/sles-installation-guide.md
+++ b/install/sles-installation-guide.md
@@ -1,5 +1,13 @@
 # Install Kata Containers on SLES
 
+> **Warning:**
+>
+> - The SLES packages are provided as a convenience to users until native
+>   packages are available in SLES. However, they are **NOT** currently tested
+>   (although openSUSE is) so caution should be exercised.
+>
+>   See https://github.com/kata-containers/ci/issues/126 for further details.
+
 1. Install the Kata Containers components with the following commands:
 
    ```bash


### PR DESCRIPTION
Unfortunately, at present we have no way of testing Kata packages for Red Hat Enterprise Linux (RHEL) or SUSE Linux Enterprise (SLES).

Add warnings to the RHEL and SLES install guides explaining this and advising users to exercise caution. Hopefully, we will be able to drop this warning soon (either when we have the ability to test on RHEL/SLES or when Kata packages are available in RHEL/SLES).

Fixes #396.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>