### PR TITLE
Add links to all how-to and use-case docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For details of the other Kata Containers repositories, see the
 * HOWTO: [OpenStack Zun with Kata Containers](zun/zun_kata.md)
 * HOWTO: [Kata Containers with Firecracker](https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support)
 * HOWTO: [Sysctls with Kata Containers](./how-to/how-to-use-sysctls-with-kata.md)
+* HOWTO: [VM Templating](./how-to/what-is-vm-cache-and-how-do-I-use-it.md) and [VM Cache](./how-to/what-is-vm-cache-and-how-do-I-use-it.md)
 
 ## Developer Guide
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ For details of the other Kata Containers repositories, see the
 * HOWTO: [Sysctls with Kata Containers](./how-to/how-to-use-sysctls-with-kata.md)
 * HOWTO: [VM Templating](./how-to/what-is-vm-cache-and-how-do-I-use-it.md) and [VM Cache](./how-to/what-is-vm-cache-and-how-do-I-use-it.md)
 
+## Kata Use-Cases
+
+* [VPP with Kata](./use-cases/using-vpp-and-kata.md)
+* [SR-IOV with Kata](./use-cases/using-SRIOV-and-kata.md)
+* [GPU Passthrough with Kata](./GPU-passthrough-and-Kata.md)
+
 ## Developer Guide
 
 Documents that help to understand and contribute to Kata Containers.


### PR DESCRIPTION
Add links to all how-to and use-case docs in README.md so that they can be navigated to. Currently there is no way to reach them except actually browsing through the repo.