### PR TITLE
howto: Remove vsock from VMCache howto

### DIFF
--- a/how-to/what-is-vm-cache-and-how-do-I-use-it.md
+++ b/how-to/what-is-vm-cache-and-how-do-I-use-it.md
@@ -41,5 +41,4 @@ and purge it by ctrl-c it.
 
 ### Limitations
 * Cannot work with VM templating.
-* Cannot work with vsock.
 * Only supports the qemu hypervisor.


### PR DESCRIPTION
Remove vsock from VMCache howto because VMCache can work with vsock now.

Fixes: #405

Signed-off-by: Hui Zhu <teawater@hyper.sh>