### PR TITLE
Undo docker pin

### DIFF
--- a/.ci/test-install-docs.sh
+++ b/.ci/test-install-docs.sh
@@ -229,14 +229,6 @@ run_tests()
 	$mgr -v -f remove-docker
 
 	test_distro_install_guide
-
-	# Remove docker in preparation for the next test.
-	#
-	# This is required since docker may have been pinned (to ensure a
-	# particular version is installed). But when a package is pinned, you
-	# cannot change it (although you can remove it).
-	$mgr -v -f remove-docker
-
 	test_alternative_install_methods
 }
 

--- a/install/docker/centos-docker-install.md
+++ b/install/docker/centos-docker-install.md
@@ -5,24 +5,17 @@
 > - This guide assumes you have
 >   [already installed the Kata Containers packages](../centos-installation-guide.md).
 
-1. Install Docker with the following commands:
+1. Install the latest version of Docker with the following commands:
 
    > **Notes:**
    >
    > - This step is only required if Docker is not installed on the system.
-   > - Newer versions of Docker have
-   >   [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373)
-   >   so the following commands install the latest version, which includes
-   >   devicemapper support.
-   > - To remove the lock on the docker package to allow it to be updated:
-   >   ```sh
-   >   $ sudo yum versionlock delete docker-ce
-   >   ```
+   > - Docker version 18.09 [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373).
+   >   If you wish to use a block based backend, see the options listed on https://github.com/kata-containers/documentation/issues/407.
 
    ```bash
    $ sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-   $ sudo yum -y install 'docker-ce-18.06.2.ce-3*' yum-plugin-versionlock
-   $ sudo yum versionlock docker-ce
+   $ sudo yum -y install docker-ce
    ```
 
    For more information on installing Docker please refer to the

--- a/install/docker/debian-docker-install.md
+++ b/install/docker/debian-docker-install.md
@@ -4,7 +4,7 @@
 >
 > - This guide assumes you have
 >   [already installed the Kata Containers packages](../debian-installation-guide.md).
-> - this guide allows for installation with `systemd` or `sysVinit` init systems
+> - This guide allows for installation with `systemd` or `sysVinit` init systems.
 
 1. Install Docker with the following commands:
 

--- a/install/docker/debian-docker-install.md
+++ b/install/docker/debian-docker-install.md
@@ -6,27 +6,20 @@
 >   [already installed the Kata Containers packages](../debian-installation-guide.md).
 > - This guide allows for installation with `systemd` or `sysVinit` init systems.
 
-1. Install Docker with the following commands:
+1. Install the latest version of Docker with the following commands:
 
    > **Notes:**
    >
    > - This step is only required if Docker is not installed on the system.
-   > - Newer versions of Docker have
-   >   [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373)
-   >   so the following commands install the latest version, which includes
-   >   devicemapper support.
-   > - To remove the lock on the docker package to allow it to be updated:
-   >   ```sh
-   >   $ sudo apt-mark unhold docker-ce
-   >   ```
+   > - Docker version 18.09 [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373).
+   >   If you wish to use a block based backend, see the options listed on https://github.com/kata-containers/documentation/issues/407.
 
    ```bash
    $ sudo apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common  
    $ curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | sudo apt-key add -
    $ sudo add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
    $ sudo apt-get update
-   $ sudo -E apt-get -y install --allow-downgrades docker-ce='18.06.2~ce~3-0~debian'
-   $ sudo apt-mark hold docker-ce
+   $ sudo -E apt-get -y install docker-ce
    ```
 
    For more information on installing Docker please refer to the

--- a/install/docker/fedora-docker-install.md
+++ b/install/docker/fedora-docker-install.md
@@ -5,28 +5,19 @@
 > - This guide assumes you have
 >   [already installed the Kata Containers packages](../fedora-installation-guide.md).
 
-1. Install Docker with the following commands:
+1. Install the latest version of Docker with the following commands:
 
    > **Notes:**
    >
    > - This step is only required if Docker is not installed on the system.
-   > - Newer versions of Docker have
-   >   [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373)
-   >   so the following commands install the latest version, which includes
-   >   devicemapper support.
-   > - To remove the lock on the docker package to allow it to be updated:
-   >   ```sh
-   >   $ sudo dnf versionlock delete docker-ce
-   >   ```
+   > - Docker version 18.09 [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373).
+   >   If you wish to use a block based backend, see the options listed on https://github.com/kata-containers/documentation/issues/407.
 
    ```bash
    $ source /etc/os-release
    $ sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
    $ sudo dnf makecache
-   $ docker_pkg='docker-ce-18.06.2.ce-3*'
-   $ [ "$VERSION_ID" -gt 28 ] && docker_pkg=docker-ce
-   $ sudo dnf -y install $docker_pkg python3-dnf-plugin-versionlock
-   $ sudo dnf versionlock docker-ce
+   $ sudo dnf -y install docker-ce
    ```
 
    For more information on installing Docker please refer to the

--- a/install/docker/opensuse-docker-install.md
+++ b/install/docker/opensuse-docker-install.md
@@ -5,24 +5,17 @@
 > - This guide assumes you have
 >   [already installed the Kata Containers packages](../opensuse-installation-guide.md).
 
-1. Install Docker with the following commands:
+1. Install the latest version of Docker with the following commands:
 
    > **Notes:**
    >
    > - This step is only required if Docker is not installed on the system.
-   > - Newer versions of Docker have
-   >   [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373)
-   >   so the following commands install the latest version, which includes
-   >   devicemapper support.
-   > - To remove the lock on the docker package to allow it to be updated:
-   >   ```sh
-   >   $ sudo zypper removelock docker
-   >   ```
+   > - Docker version 18.09 [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373).
+   >   If you wish to use a block based backend, see the options listed on https://github.com/kata-containers/documentation/issues/407.
 
    ```bash
    $ sudo zypper -n install libcgroup1
-   $ sudo zypper -n install 'docker<18.09'
-   $ sudo zypper addlock docker
+   $ sudo zypper -n install docker
    ```
 
    For more information on installing Docker please refer to the

--- a/install/docker/rhel-docker-install.md
+++ b/install/docker/rhel-docker-install.md
@@ -7,7 +7,11 @@
 
 1. Install the latest version of Docker with the following commands:
 
-   > **Note:** This step is only required if Docker is not installed on the system.
+   > **Notes:**
+   >
+   > - This step is only required if Docker is not installed on the system.
+   > - Docker version 18.09 [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373).
+   >   If you wish to use a block based backend, see the options listed on https://github.com/kata-containers/documentation/issues/407.
 
    ```bash
    $ export rhel_devtoolset_version="7"

--- a/install/docker/sles-docker-install.md
+++ b/install/docker/sles-docker-install.md
@@ -5,23 +5,16 @@
 > - This guide assumes you have
 >   [already installed the Kata Containers packages](../sles-installation-guide.md).
 
-1. Install Docker with the following commands:
+1. Install the latest version of Docker with the following commands:
 
    > **Notes:**
    >
    > - This step is only required if Docker is not installed on the system.
-   > - Newer versions of Docker have
-   >   [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373)
-   >   so the following commands install the latest version, which includes
-   >   devicemapper support.
-   > - To remove the lock on the docker package to allow it to be updated:
-   >   ```sh
-   >   $ sudo zypper removelock docker
-   >   ```
+   > - Docker version 18.09 [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373).
+   >   If you wish to use a block based backend, see the options listed on https://github.com/kata-containers/documentation/issues/407.
 
    ```bash
-   $ sudo zypper -n install 'docker<18.09'
-   $ sudo zypper addlock docker
+   $ sudo zypper -n install docker
    ```
 
    For more information on installing Docker please refer to the

--- a/install/docker/ubuntu-docker-install.md
+++ b/install/docker/ubuntu-docker-install.md
@@ -5,19 +5,13 @@
 > - This guide assumes you have
 >   [already installed the Kata Containers packages](../ubuntu-installation-guide.md).
 
-1. Install Docker with the following commands:
+1. Install the latest version of Docker with the following commands:
 
    > **Notes:**
    >
    > - This step is only required if Docker is not installed on the system.
-   > - Newer versions of Docker have
-   >   [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373)
-   >   so the following commands install the latest version, which includes
-   >   devicemapper support.
-   > - To remove the lock on the docker package to allow it to be updated:
-   >   ```sh
-   >   $ sudo apt-mark unhold docker-ce
-   >   ```
+   > - Docker version 18.09 [removed devicemapper support](https://github.com/kata-containers/documentation/issues/373).
+   >   If you wish to use a block based backend, see the options listed on https://github.com/kata-containers/documentation/issues/407.
 
    ```bash
    $ sudo -E apt-get -y install apt-transport-https ca-certificates software-properties-common
@@ -25,8 +19,7 @@
    $ arch=$(dpkg --print-architecture)
    $ sudo -E add-apt-repository "deb [arch=${arch}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
    $ sudo -E apt-get update
-   $ sudo -E apt-get -y install --allow-downgrades docker-ce='18.06.2~ce~3-0~ubuntu'
-   $ sudo apt-mark hold docker-ce
+   $ sudo -E apt-get -y install docker-ce
    ```
 
    For more information on installing Docker please refer to the


### PR DESCRIPTION
Don't force Docker to be kept at version 18.06 (to ensure devicemapper is available). This feature won't be re-added by Docker and remaining on an old version of Docker is not good from a security perspective.

Replace the pinning with a note pointing users at an issue which provides details of alternatives to devicemapper.

Fixes #407.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>