### PR TITLE
docs: Fix debug console for ubuntu/debian

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -657,7 +657,7 @@ StandardOutput=tty
 # Must be disabled to allow the job to access the real console
 PrivateDevices=no
 Type=simple
-ExecStart=/usr/bin/bash
+ExecStart=/bin/bash
 Restart=always
 EOT
 ```


### PR DESCRIPTION
Change the debug console systemd job to specify the path to bash as `/bin/bash`, *not* `/usr/bin/bash`. This unbreaks the debug console for Ubuntu and Debian and also works for all other distros.

Fixes #410.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>