### PR TITLE
docs: Explain systemd needed for debug console

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -627,6 +627,18 @@ boot the virtual machine.
 If you want to login to a virtual machine that hosts your containers, complete
 the following steps, which assume the use of a rootfs image.
 
+> **Note:** The debug console instructions below assume a systemd based guest
+> O/S image meaning you must create a rootfs for a distro that supports
+> systemd. Currently, all distros supported by
+> [osbuilder](https://github.com/kata-containers/osbuilder) support systemd,
+> except for Alpine Linux. To check if a distro supports systemd look for
+> `INIT_PROCESS=systemd` in the `config.sh` osbuilder rootfs config file for
+> the distro you wish to build a rootfs for (for example see the [Clear Linux
+> `config.sh`
+> file](https://github.com/kata-containers/osbuilder/blob/master/rootfs-builder/clearlinux/config.sh)).
+> For non-systemd based distros, you will need to create an equivalent system
+> service using that distros init system syntax instead.
+
 ### Create a custom image containing a shell
 
 To login to a virtual machine, you must


### PR DESCRIPTION
Add a note to the developer guide explaining that the debug console requires systemd support (hence nominally you cannot use alpine linux for example as that doesn't use systemd).

Fixes #412.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>