### PR TITLE
doc: Update SLES installation documentation

### DIFF
--- a/install/sles-installation-guide.md
+++ b/install/sles-installation-guide.md
@@ -1,13 +1,5 @@
 # Install Kata Containers on SLES
 
-> **Warning:**
->
-> - The SLES packages are provided as a convenience to users until native
->   packages are available in SLES. However, they are **NOT** currently tested
->   (although openSUSE is) so caution should be exercised.
->
->   See https://github.com/kata-containers/ci/issues/126 for further details.
-
 1. Install the Kata Containers components with the following commands:
 
    ```bash


### PR DESCRIPTION
Remove the warning as a CI of SLES in available
https://github.com/kata-containers/ci/pull/142.

Fixes #425

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>