### PR TITLE
Fix debian docker install

### DIFF
--- a/install/debian-installation-guide.md
+++ b/install/debian-installation-guide.md
@@ -2,30 +2,30 @@
 
 1. Install the unsatisfied dependencies
 
-  Kata Containers packages depends on a version of `librbd1` that's not yet available in the `stable` repo.
-  A more recent version of `librbd1` can be installed from the `unstable` repo: https://packages.debian.org/sid/librbd1
+   Kata Containers packages depends on a version of `librbd1` that's not yet available in the `stable` repo.
+   A more recent version of `librbd1` can be installed from the `unstable` repo: https://packages.debian.org/sid/librbd1
 
-  Add `unstable` repo to `/etc/apt/sources.list.d/unstable.list` sources list:
-  
-  ```bash
-  $ sudo sh -c "echo '# for unstable packages
-  deb http://ftp.debian.org/debian/ unstable main contrib non-free
-  deb-src http://ftp.debian.org/debian/ unstable main contrib non-free' > /etc/apt/sources.list.d/unstable.list"
-  ```
-  
-  Set the repository to a lower priority than stable, to ensures that APT will prefer stable packages over unstable ones. This can be specified in `/etc/apt/preferences.d/unstable`:
-  
-  ```bash
-  $ sudo sh -c "echo 'Package: *
-  Pin: release a=unstable
-  Pin-Priority: 10' >> /etc/apt/preferences.d/unstable"
-  ```
+   Add `unstable` repo to `/etc/apt/sources.list.d/unstable.list` sources list:
 
-  Finally, install `librbd1`:
+   ```bash
+   $ sudo sh -c "echo '# for unstable packages
+   deb http://ftp.debian.org/debian/ unstable main contrib non-free
+   deb-src http://ftp.debian.org/debian/ unstable main contrib non-free' > /etc/apt/sources.list.d/unstable.list"
+   ```
 
-  ```bash 
-  $ sudo apt-get update && sudo apt-get install -y -t unstable librbd1
-  ```
+   Set the repository to a lower priority than stable, to ensures that APT will prefer stable packages over unstable ones. This can be specified in `/etc/apt/preferences.d/unstable`:
+
+   ```bash
+   $ sudo sh -c "echo 'Package: *
+   Pin: release a=unstable
+   Pin-Priority: 10' >> /etc/apt/preferences.d/unstable"
+   ```
+
+   Finally, install `librbd1`:
+
+   ```bash
+   $ sudo apt-get update && sudo apt-get install -y -t unstable librbd1
+   ```
 
 2. Install the Kata Containers components with the following commands:
 

--- a/install/docker/centos-docker-install.md
+++ b/install/docker/centos-docker-install.md
@@ -23,46 +23,46 @@
 
 2. Configure Docker to use Kata Containers by default with one of the following methods:
 
-    1. systemd
+   1. systemd
 
-        ```bash
-        $ sudo mkdir -p /etc/systemd/system/docker.service.d/
-        $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
-        [Service]
-        ExecStart=
-        ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
-        EOF
-        ```
+       ```bash
+       $ sudo mkdir -p /etc/systemd/system/docker.service.d/
+       $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
+       [Service]
+       ExecStart=
+       ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+       EOF
+       ```
 
-    2. Docker `daemon.json`
+   2. Docker `daemon.json`
 
-        Add the following definitions to `/etc/docker/daemon.json`:
+       Add the following definitions to `/etc/docker/daemon.json`:
 
-        ```json
-        {
-          "default-runtime": "kata-runtime",
-          "runtimes": {
-            "kata-runtime": {
-              "path": "/usr/bin/kata-runtime"
-            }
-          }
-        }
-        ```
+       ```json
+       {
+         "default-runtime": "kata-runtime",
+         "runtimes": {
+           "kata-runtime": {
+             "path": "/usr/bin/kata-runtime"
+           }
+         }
+       }
+       ```
 
 3. Restart the Docker systemd service with the following commands:
 
-    ```bash
-    $ sudo systemctl daemon-reload
-    $ sudo systemctl restart docker
-    ```
+   ```bash
+   $ sudo systemctl daemon-reload
+   $ sudo systemctl restart docker
+   ```
 
 4. Run Kata Containers
 
-    You are now ready to run Kata Containers:
+   You are now ready to run Kata Containers:
 
-    ```bash
-    $ sudo docker run busybox uname -a
-    ```
+   ```bash
+   $ sudo docker run busybox uname -a
+   ```
 
-    The previous command shows details of the kernel version running inside the
-    container, which is different to the host kernel version.
+   The previous command shows details of the kernel version running inside the
+   container, which is different to the host kernel version.

--- a/install/docker/centos-docker-install.md
+++ b/install/docker/centos-docker-install.md
@@ -65,4 +65,4 @@
     ```
 
     The previous command shows details of the kernel version running inside the
-    container, which is different from the host kernel version.
+    container, which is different to the host kernel version.

--- a/install/docker/debian-docker-install.md
+++ b/install/docker/debian-docker-install.md
@@ -31,7 +31,7 @@ a. sysVinit
     
     - with sysVinit,  docker config is stored in `/etc/default/docker`, edit the options similar to the following: 
        
-    ```
+    ```sh
     $ sudo sh -c "echo '# specify docker runtime for kata-containers
     DOCKER_OPTS=\"-D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime\"' >> /etc/default/docker"
     ```
@@ -47,34 +47,34 @@ b. systemd
     EOF
     ```
 
-c. systemd Docker `daemon.json`
+c. Docker `daemon.json`
 
     Add the following definitions to `/etc/docker/daemon.json`:
 
-    ```bash
-    $ sudo sh -c "echo '{
-      \"default-runtime\": \"kata-runtime\",
-      \"runtimes\": {
-        \"kata-runtime\": {
-          \"path\": \"/usr/bin/kata-runtime\"
+    ```json
+    {
+      "default-runtime": "kata-runtime",
+      "runtimes": {
+        "kata-runtime": {
+          "path": "/usr/bin/kata-runtime"
         }
       }
-    }' >> /etc/docker/daemon.json"
+    }
     ```
 
 3. Restart the Docker systemd service with one of the following (depending on init choice):
 
     a. sysVinit
   
-    ```bash
+    ```sh
     $ sudo /etc/init.d/docker stop
     $ sudo /etc/init.d/docker start
     ```
 
-    to watch for errors:
+    To watch for errors:
 
-    ```bash
-    tail -f /var/log/docker.log
+    ```sh
+    $ tail -f /var/log/docker.log
     ```
     
     b. systemd
@@ -94,6 +94,3 @@ c. systemd Docker `daemon.json`
 
    The previous command shows details of the kernel version running inside the
    container, which is different to the host kernel version.
-
-   
-   

--- a/install/docker/fedora-docker-install.md
+++ b/install/docker/fedora-docker-install.md
@@ -25,31 +25,31 @@
 
 2. Configure Docker to use Kata Containers by default with one of the following methods:
 
-    1. systemd
+   1. systemd
 
-        ```bash
-        $ sudo mkdir -p /etc/systemd/system/docker.service.d/
-        $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
-        [Service]
-        ExecStart=
-        ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
-        EOF
-        ```
+       ```bash
+       $ sudo mkdir -p /etc/systemd/system/docker.service.d/
+       $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
+       [Service]
+       ExecStart=
+       ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+       EOF
+       ```
 
-    2. Docker `daemon.json`
+   2. Docker `daemon.json`
 
-        Add the following definitions to `/etc/docker/daemon.json`:
+       Add the following definitions to `/etc/docker/daemon.json`:
 
-        ```json
-        {
-          "default-runtime": "kata-runtime",
-          "runtimes": {
-            "kata-runtime": {
-              "path": "/usr/bin/kata-runtime"
-            }
-          }
-        }
-        ```
+       ```json
+       {
+         "default-runtime": "kata-runtime",
+         "runtimes": {
+           "kata-runtime": {
+             "path": "/usr/bin/kata-runtime"
+           }
+         }
+       }
+       ```
 
 3. Restart the Docker systemd service with the following commands:
 

--- a/install/docker/rhel-docker-install.md
+++ b/install/docker/rhel-docker-install.md
@@ -24,31 +24,31 @@
 
 2. Configure Docker to use Kata Containers by default with one of the following methods:
 
-    1. systemd
+   1. systemd
 
-        ```bash
-        $ sudo mkdir -p /etc/systemd/system/docker.service.d/
-        $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
-        [Service]
-        ExecStart=
-        ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
-        EOF
-        ```
+       ```bash
+       $ sudo mkdir -p /etc/systemd/system/docker.service.d/
+       $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
+       [Service]
+       ExecStart=
+       ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+       EOF
+       ```
 
-    2. Docker `daemon.json`
+   2. Docker `daemon.json`
 
-        Add the following definitions to `/etc/docker/daemon.json`:
+       Add the following definitions to `/etc/docker/daemon.json`:
 
-        ```json
-        {
-          "default-runtime": "kata-runtime",
-          "runtimes": {
-            "kata-runtime": {
-              "path": "/usr/bin/kata-runtime"
-            }
-          }
-        }
-        ```
+       ```json
+       {
+         "default-runtime": "kata-runtime",
+         "runtimes": {
+           "kata-runtime": {
+             "path": "/usr/bin/kata-runtime"
+           }
+         }
+       }
+       ```
 
 3. Restart the Docker systemd service with the following commands:
 

--- a/install/docker/sles-docker-install.md
+++ b/install/docker/sles-docker-install.md
@@ -20,7 +20,7 @@
    For more information on installing Docker please refer to the
    [Docker Guide](https://www.suse.com/documentation/sles-12/singlehtml/book_sles_docker/book_sles_docker.html).
 
-2. Configure Docker to use Kata Containers with one of the following methods:
+2. Configure Docker to use Kata Containers by default with one of the following methods:
 
    1. systemd
 

--- a/install/docker/ubuntu-docker-install.md
+++ b/install/docker/ubuntu-docker-install.md
@@ -27,31 +27,31 @@
 
 2. Configure Docker to use Kata Containers by default with one of the following methods:
 
-    1. systemd
+   1. systemd
 
-        ```bash
-        $ sudo mkdir -p /etc/systemd/system/docker.service.d/
-        $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
-        [Service]
-        ExecStart=
-        ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
-        EOF
-        ```
+       ```bash
+       $ sudo mkdir -p /etc/systemd/system/docker.service.d/
+       $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
+       [Service]
+       ExecStart=
+       ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
+       EOF
+       ```
 
-    2. Docker `daemon.json`
+   2. Docker `daemon.json`
 
-        Add the following definitions to `/etc/docker/daemon.json`:
+       Add the following definitions to `/etc/docker/daemon.json`:
 
-        ```json
-        {
-          "default-runtime": "kata-runtime",
-          "runtimes": {
-            "kata-runtime": {
-              "path": "/usr/bin/kata-runtime"
-            }
-          }
-        }
-        ```
+       ```json
+       {
+         "default-runtime": "kata-runtime",
+         "runtimes": {
+           "kata-runtime": {
+             "path": "/usr/bin/kata-runtime"
+           }
+         }
+       }
+       ```
 
 3. Restart the Docker systemd service with the following commands:
 

--- a/install/ubuntu-installation-guide.md
+++ b/install/ubuntu-installation-guide.md
@@ -1,6 +1,7 @@
 # Install Kata Containers on Ubuntu
 
 1. Install the Kata Containers components with the following commands:
+
    ```bash
    $ ARCH=$(arch)
    $ BRANCH="${BRANCH:-master}"


### PR DESCRIPTION
Fix installing docker on Debian by changing the docker install guide to ensure that only the `kata-containers.conf` systemd service snippet is created. Previously, both the snippet and the `daemon.json` Docker config files were being updated because the latter also specified a bash code block.

Note that the `daemon.json` section is now consistent with the other install guides - it just displays the JSON code to add rather than trying to set it.

Also, added missing shell prompts, changed code blocks into shell (but not bash) code blocks and fixed a few minor grammar and whitespace issues across all install guides.

For further details, see:

- https://github.com/kata-containers/documentation/blob/master/Documentation-Requirements.md
- https://github.com/kata-containers/tests/tree/master/cmd/kata-manager

Fixes #442.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>