### PR TITLE
docs: Remove ps command from Limitations

### DIFF
--- a/Limitations.md
+++ b/Limitations.md
@@ -6,7 +6,6 @@
     * [Runtime commands](#runtime-commands)
         * [checkpoint and restore](#checkpoint-and-restore)
         * [events command](#events-command)
-        * [ps command](#ps-command)
         * [update command](#update-command)
     * [Networking](#networking)
         * [Adding networks dynamically](#adding-networks-dynamically)


### PR DESCRIPTION
Remove the link of ps command from Limitations document.

Fixes #324

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>