### PR TITLE
docs: Fix incorrect link in limitations TOC

### DIFF
--- a/Limitations.md
+++ b/Limitations.md
@@ -1,5 +1,5 @@
 * [Overview](#overview)
-* [Definition of a limitation](#definiton-of-a-limitation)
+* [Definition of a limitation](#definition-of-a-limitation)
 * [Scope](#scope)
 * [Contributing](#contributing)
 * [Pending items](#pending-items)


### PR DESCRIPTION
Fixed typo in table of contents link name which broke the link.

Fixes #456.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>