### PR TITLE
how-to: fix kubadm command

### DIFF
--- a/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
+++ b/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
@@ -119,7 +119,7 @@ $ sudo systemctl daemon-reload
 - Start cluster using `kubeadm`
 
   ```bash
-  $ sudo kubeadm init --skip-preflight-checks --cri-socket /run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16
+  $ sudo kubeadm init --cri-socket /run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16
   $ export KUBECONFIG=/etc/kubernetes/admin.conf
   $ sudo -E kubectl get nodes
   $ sudo -E kubectl get pods


### PR DESCRIPTION
remove `--skip-preflight-checks` option since it has been deprecated

fixes #460

Signed-off-by: Julio Montes <julio.montes@intel.com>