### PR TITLE
how-to: virtio-fs initial documentation

### DIFF
--- a/how-to/how-to-use-virtio-fs-with-kata.md
+++ b/how-to/how-to-use-virtio-fs-with-kata.md
@@ -1,13 +1,19 @@
-
 # Kata Containers with virtio-fs
 
-* [Introduction](#introduction)
-* [Pre-requisites](#pre-requisites)
-* [Configure Kata Containers](#configure-kata-containers)
+- [Introduction](#introduction)
+- [Pre-requisites](#pre-requisites)
+- [Install Kata Containers with virtio-fs support](#install-kata-containers-with-virtio-fs-support)
+- [Run a Kata Container utilizing virtio-fs](#run-a-kata-container-utilizing-virtio-fs)
 
 ## Introduction
 
-[virtio-fs](https://virtio-fs.gitlab.io/) is a shared file system that lets virtual machines access a directory tree on the host. In Kata, virtio-fs can be used to share the rootfs of the container on the host within the guest to provide significant performance improvements over 9p (the current default sharing mechanism).
+Container deployments utilize explicit or implicit file sharing between host filesystem and containers. From a trust perspective, avoiding a shared file-system between the trusted host and untrusted container is recommended. This is not always feasible. In Kata Containers, block-based volumes are prefered as they allow usage of either device pass through or virtio-blk for access within the virtual machine.
+
+As of the 1.7 release of Kata Containers, [9pfs](https://www.kernel.org/doc/Documentation/filesystems/9p.txt) is the default filesystem sharing mechanism. While this does allow for workload compatability, it does so with degraded performance and potential for POSIX compliance limitations.
+
+To help address these limitations, [virtio-fs](https://virtio-fs.gitlab.io/) has been developed. virtio-fs is a shared file system that lets virtual machines access a directory tree on the host. In Kata Containers, virtio-fs can be used to share container volumes, secrets, config-maps, configuration files (hostname, hosts, resolv.conf) and the container rootfs on the host with the guest.  virtio-fs provides significant performance and POSIX compliance improvements compared to 9pfs.
+
+Enabling of virtio-fs requires changes in the guest kernel as well as the VMM. For Kata Containers, experimental virtio-fs support is enabled through the [NEMU VMM](https://github.com/intel/nemu).
 
 **Note: virtio-fs support is experimental in the 1.7 release of Kata Containers. Work is underway to improve stability, performance and upstream integration. This is available for early preview - use at your own risk**
 
@@ -15,62 +21,30 @@ This document describes how to get Kata Containers to work with virtio-fs.
 
 ## Pre-requisites
 
-This document requires Kata Containers to be [installed](https://github.com/kata-containers/documentation/blob/master/install/README.md) on your system.
-
-* virtio-fs is currently only available with [NEMU](https://github.com/kata-containers/documentation/blob/master/how-to/how-to-use-kata-containers-with-nemu.md)
 * This feature currently requires the host to have hugepages support enabled. Enable this with the `sysctl vm.nr_hugepages=1024` command on the host.
 
-## Configure Kata Containers
+## Install Kata Containers with virtio-fs support
 
-To configure Kata Containers, modify the configuration file `/usr/share/defaults/kata-containers/configuration.toml` to specify the below options related to this feature.
+The Kata Containers NEMU configuration, the NEMU VMM and the virtiofs daemon are available in the [Kata Container release](https://github.com/kata-containers/runtime/releases) artifacts starting with the 1.7 release. While the feature is experimental, distribution packages are not supported, but installation is available through [kata-deploy](https://github.com/kata-containers/packaging/tree/master/kata-deploy).
 
-```diff
- [hypervisor.qemu]
--path = "/usr/bin/qemu-lite-system-x86_64"
-+path = "/home/foo/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt"
- kernel = "/usr/share/kata-containers/vmlinuz.container"
- initrd = "/usr/share/kata-containers/kata-containers-initrd.img"
- image = "/usr/share/kata-containers/kata-containers.img"
--machine_type = "pc"
-+machine_type = "virt"
-
- # Optional space-separated list of options to pass to the guest kernel.
- # For example, use `kernel_params = "vsyscall=emulate"` if you are having
-@@ -31,7 +31,7 @@ kernel_params = ""
-
- # Path to the firmware.
- # If you want that qemu uses the default firmware leave this option empty
--firmware = ""
-+firmware = "/usr/share/nemu/OVMF.fd"
-
- # Machine accelerators
- # comma-separated list of machine accelerators to pass to the hypervisor.
-@@ -100,10 +100,10 @@ disable_block_device_use = false
- # Shared file system type:
- #   - virtio-9p (default)
- #   - virtio-fs
--shared_fs = "virtio-9p"
-+shared_fs = "virtio-fs"
-
- # Path to vhost-user-fs daemon.
--virtio_fs_daemon = ""
-+virtio_fs_daemon = "/home/foo/build-x86_64_virt/virtiofsd-x86_64"
+Install the latest release of Kata as follows:
+```
+docker run --runtime=runc -v /opt/kata:/opt/kata -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd -v /etc/docker:/etc/docker -it katadocker/kata-deploy kata-deploy-docker install
 ```
 
-As you can see from the previous snippet, you only need to change the following:
-- the path to the hypervisor binary. `/home/foo/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt` in this example.
-- The machine name from `pc` to `virt`,
-- The path of the firmware binary, `/usr/share/nemu/OVMF.fd` in this example,
-- The `shared_fs` option to `virtio_fs`,
-- The path of the virtiofsd daemon. `/home/foo/build-x86_64_virt/virtiofsd-x86_64` in this example.
+This will place the Kata release artifacts in `/opt/kata`, and update Docker's configuration to include a runtime target, `kata-nemu`. Learn more about kata-deploy and how to use kata-deploy in Kubernetes [here](https://github.com/kata-containers/packaging/tree/master/kata-deploy#kubernetes-quick-start).
 
-Once you save these modifications, start a new container:
+
+## Run a Kata Container utilizing virtio-fs
+
+Once installed, start a new container, utilizing NEMU + virtiofs:
 ```bash
-$ docker run --runtime=kata-runtime -it busybox
+$ docker run --runtime=kata-nemu -it busybox
 ```
+
 Verify the new container is running with the NEMU hypervisor as well as using virtiofsd. To do this look for the hypervisor path and the virtiofs daemon process on the host:
 ```bash
-$ ps -aux | grep virt
+$ ps -aux | grep virtiofs
 root ... /home/foo/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt
 ...  -machine virt,accel=kvm,kernel_irqchip,nvdimm ...
 root ... /home/foo/build-x86_64_virt/virtiofsd-x86_64 ...

--- a/how-to/how-to-use-virtio-fs-with-kata.md
+++ b/how-to/how-to-use-virtio-fs-with-kata.md
@@ -1,0 +1,77 @@
+
+# Kata Containers with virtio-fs
+
+* [Introduction](#introduction)
+* [Pre-requisites](#pre-requisites)
+* [Configure Kata Containers](#configure-kata-containers)
+
+## Introduction
+
+[virtio-fs](https://virtio-fs.gitlab.io/) is a shared file system that lets virtual machines access a directory tree on the host. In Kata, virtio-fs can be used to share the rootfs of the container on the host within the guest to provide significant performance improvements over 9p (the current default sharing mechanism).
+
+**Note: virtio-fs support is experimental in the 1.7 release of Kata Containers. Work is underway to improve stability, performance and upstream integration. This is available for early preview - use at your own risk**
+
+This document describes how to get Kata Containers to work with virtio-fs.
+
+## Pre-requisites
+
+This document requires Kata Containers to be [installed](https://github.com/kata-containers/documentation/blob/master/install/README.md) on your system.
+
+* virtio-fs is currently only available with [NEMU](https://github.com/kata-containers/documentation/blob/master/how-to/how-to-use-kata-containers-with-nemu.md)
+* This feature currently requires the host to have hugepages support enabled. Enable this with the `sysctl vm.nr_hugepages=1024` command on the host.
+
+## Configure Kata Containers
+
+To configure Kata Containers, modify the configuration file `/usr/share/defaults/kata-containers/configuration.toml` to specify the below options related to this feature.
+
+```diff
+ [hypervisor.qemu]
+-path = "/usr/bin/qemu-lite-system-x86_64"
++path = "/home/foo/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt"
+ kernel = "/usr/share/kata-containers/vmlinuz.container"
+ initrd = "/usr/share/kata-containers/kata-containers-initrd.img"
+ image = "/usr/share/kata-containers/kata-containers.img"
+-machine_type = "pc"
++machine_type = "virt"
+
+ # Optional space-separated list of options to pass to the guest kernel.
+ # For example, use `kernel_params = "vsyscall=emulate"` if you are having
+@@ -31,7 +31,7 @@ kernel_params = ""
+
+ # Path to the firmware.
+ # If you want that qemu uses the default firmware leave this option empty
+-firmware = ""
++firmware = "/usr/share/nemu/OVMF.fd"
+
+ # Machine accelerators
+ # comma-separated list of machine accelerators to pass to the hypervisor.
+@@ -100,10 +100,10 @@ disable_block_device_use = false
+ # Shared file system type:
+ #   - virtio-9p (default)
+ #   - virtio-fs
+-shared_fs = "virtio-9p"
++shared_fs = "virtio-fs"
+
+ # Path to vhost-user-fs daemon.
+-virtio_fs_daemon = ""
++virtio_fs_daemon = "/home/foo/build-x86_64_virt/virtiofsd-x86_64"
+```
+
+As you can see from the previous snippet, you only need to change the following:
+- the path to the hypervisor binary. `/home/foo/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt` in this example.
+- The machine name from `pc` to `virt`,
+- The path of the firmware binary, `/usr/share/nemu/OVMF.fd` in this example,
+- The `shared_fs` option to `virtio_fs`,
+- The path of the virtiofsd daemon. `/home/foo/build-x86_64_virt/virtiofsd-x86_64` in this example.
+
+Once you save these modifications, start a new container:
+```bash
+$ docker run --runtime=kata-runtime -it busybox
+```
+Verify the new container is running with the NEMU hypervisor as well as using virtiofsd. To do this look for the hypervisor path and the virtiofs daemon process on the host:
+```bash
+$ ps -aux | grep virt
+root ... /home/foo/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt
+...  -machine virt,accel=kvm,kernel_irqchip,nvdimm ...
+root ... /home/foo/build-x86_64_virt/virtiofsd-x86_64 ...
+```


### PR DESCRIPTION
virtio-fs has landed as an experimental feature in kata. This patch
enable the basic how-to for this feature.

Fixes: #468
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>