### PR TITLE
docs: Require all new docs to be referenced

### DIFF
--- a/Documentation-Requirements.md
+++ b/Documentation-Requirements.md
@@ -20,6 +20,14 @@ All documents must:
 - Have a `.md` file extension.
 - Include a TOC (table of contents) at the top of the document with links to
   all heading sections.
+- Be linked to from another document in the same repository.
+
+  Although GitHub allows navigation of the entire repository, it should be
+  possible to access all documentation purely by navigating links inside the
+  documents, starting from the repositories top-level `README`.
+
+  If you are adding a new document, ensure you add a link to it in the
+  "closest" `README` above the directory where you created your document.
 
 # Linking advice
 


### PR DESCRIPTION
New documentation is great, but finding it should be easy. Require that all new docs are referenced by an existing document in the repo.

Fixes #475.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>