### PR TITLE
docs: Advise use of non-interactive commands

### DIFF
--- a/Documentation-Requirements.md
+++ b/Documentation-Requirements.md
@@ -28,6 +28,13 @@ All documents must:
 
   If you are adding a new document, ensure you add a link to it in the
   "closest" `README` above the directory where you created your document.
+- If the document needs to tell the user to manipulate files or commands, use a
+  [code block](#code-blocks) to specify the commands.
+
+  If at all possible, ensure that every command in the code blocks can be run
+  non-interactively. If this is possible, the document can be tested by the CI
+  which can then execute the commands specified to ensure the instructions are
+  correct. This avoids documents becoming out of date over time.
 
 # Linking advice
 

--- a/Documentation-Requirements.md
+++ b/Documentation-Requirements.md
@@ -109,7 +109,7 @@ utility.
 
 - If a document includes commands the user should run, they **MUST** be shown
   in a *bash code block* with every command line prefixed with `$ ` to denote
-  a prompt:
+  a shell prompt:
 
   ```
 

--- a/Documentation-Requirements.md
+++ b/Documentation-Requirements.md
@@ -123,6 +123,7 @@ utility.
 
 - If a command needs to be run as the `root` user, it must be run using
   `sudo(8)`.
+
   ```bash
 
   $ sudo echo "I'm running as root"


### PR DESCRIPTION
If a doc contains commands, they should be non-interactive where possible to allow for the possibility of automating the testing of the document in the CI.

Fixes #477.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>