### PR TITLE
install: better support for all openSUSE distros

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -49,7 +49,7 @@ Manual installation instructions are available for [these distributions](#suppor
 1. Add the Kata Containers repository to your distro package manager, and import the packages signing key.
 2. Install the Kata Containers packages.
 3. Install a supported container manager.
-4. Configure the container manager to use `kata-runtime` as the default OCI runtime. Or, for Kata Containers 1.5.0 or above, configure the 
+4. Configure the container manager to use `kata-runtime` as the default OCI runtime. Or, for Kata Containers 1.5.0 or above, configure the
    `io.containerd.kata.v2` to be the runtime shim (see [containerd runtime v2 (shim API)](https://github.com/containerd/containerd/tree/master/runtime/v2)
    and [How to use Kata Containers and CRI (containerd plugin) with Kubernetes](https://github.com/kata-containers/documentation/blob/master/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md)).
 
@@ -83,15 +83,15 @@ Manual installation instructions are available for [these distributions](#suppor
 [Use snap](snap-installation-guide.md) to install Kata Containers from snapcraft.io.
 
 #### Supported Distributions
-|Distro specific installation instructions                          | Versions        |
-|-------------------------------------------------------------------|-----------------|
-|[CentOS](centos-installation-guide.md)                             | 7               |
-|[Debian](debian-installation-guide.md)                             | 9               |
-|[Fedora](fedora-installation-guide.md)                             | 27, 28          |
-|[openSUSE](opensuse-installation-guide.md)                         | Leap (42.3)     |
-|[Red Hat Enterprise Linux (RHEL)](rhel-installation-guide.md)      | 7               |
-|[SUSE Linux Enterprise Server (SLES)](sles-installation-guide.md)  | SLES 12 SP3     |
-|[Ubuntu](ubuntu-installation-guide.md)                             | 16.04, 18.04    |
+|Distro specific installation instructions                        | Versions                                                                                                          |
+|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+|[CentOS](centos-installation-guide.md)                           | 7                                                                                                                 |
+|[Debian](debian-installation-guide.md)                           | 9                                                                                                                 |
+|[Fedora](fedora-installation-guide.md)                           | 27, 28, 29                                                                                                        |
+|[openSUSE](opensuse-installation-guide.md)                       | [Leap](opensuse-leap-installation-guide.md) (42.3, 15)<br>[Tumbleweed](opensuse-tumbleweed-installation-guide.md) |
+|[Red Hat Enterprise Linux (RHEL)](rhel-installation-guide.md)    | 7                                                                                                                 |
+|[SUSE Linux Enterprise Server (SLES)](sles-installation-guide.md)| SLES 12 SP3                                                                                                       |
+|[Ubuntu](ubuntu-installation-guide.md)                           | 16.04, 18.04                                                                                                      |
 
 ## Installing on a Cloud Service Platform
 * [Amazon Web Services (AWS)](aws-installation-guide.md)

--- a/install/docker/opensuse-docker-install.md
+++ b/install/docker/opensuse-docker-install.md
@@ -1,4 +1,4 @@
-# Install Docker for Kata Containers on openSUSE Leap
+# Install Docker for Kata Containers on openSUSE Leap/Tumbleweed
 
 > **Note:**
 >

--- a/install/docker/opensuse-docker-install.md
+++ b/install/docker/opensuse-docker-install.md
@@ -1,4 +1,4 @@
-# Install Docker for Kata Containers on openSUSE Leap/Tumbleweed
+# Install Docker for Kata Containers on openSUSE
 
 > **Note:**
 >
@@ -14,24 +14,24 @@
    >   If you wish to use a block based backend, see the options listed on https://github.com/kata-containers/documentation/issues/407.
 
    ```bash
-   $ sudo zypper -n install libcgroup1
    $ sudo zypper -n install docker
    ```
 
    For more information on installing Docker please refer to the
    [Docker Guide](https://software.opensuse.org/package/docker).
 
-2. Configure Docker to use Kata Containers by default with one of the following methods:
+2. Configure the Docker daemon to use Kata Containers by default, with one of the following methods:
 
-   1. systemd
+   1. Specify the runtime options in `/etc/sysconfig/docker`:
 
        ```bash
-       $ sudo mkdir -p /etc/systemd/system/docker.service.d/
-       $ cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/kata-containers.conf
-       [Service]
-       ExecStart=
-       ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime
-       EOF
+       $ DOCKER_SYSCONFIG=/etc/sysconfig/docker
+       # Add kata-runtime to the list of available runtimes, if not already listed
+       $ grep -qE "^ *DOCKER_OPTS=.+--add-runtime[= ] *kata-runtime" $DOCKER_SYSCONFIG || sudo -E sed -i -E "s|^( *DOCKER_OPTS=.+)\" *$|\1 --add-runtime kata-runtime=/usr/bin/kata-runtime\"|g" $DOCKER_SYSCONFIG
+       # If a current default runtime is specified, overwrite it with kata-runtime
+       $ sudo -E sed -i -E "s|^( *DOCKER_OPTS=.+--default-runtime[= ] *)[^ \"]+(.*\"$)|\1kata-runtime\2|g" $DOCKER_SYSCONFIG
+       # Add kata-runtime as default runtime, if no default runtime is specified
+       $ grep -qE "^ *DOCKER_OPTS=.+--default-runtime" $DOCKER_SYSCONFIG || sudo -E sed -i -E "s|^( *DOCKER_OPTS=.+)(\"$)|\1 --default-runtime=kata-runtime\2|g" $DOCKER_SYSCONFIG
        ```
 
    2. Docker `daemon.json`

--- a/install/docker/opensuse-leap-docker-install.md
+++ b/install/docker/opensuse-leap-docker-install.md
@@ -1,0 +1,14 @@
+# Install Docker for Kata Containers on openSUSE Leap
+
+Follow the instructions in the generic [openSUSE Docker install guide](opensuse-docker-install.md).
+<!--
+You can ignore the content of this comment.
+(test code run by test-install-docs.sh to validate code blocks this document)
+
+```bash
+$ echo "NOTE: this document is just a link to the generic openSUSE install guide located at:
+https://raw.githubusercontent.com/kata-containers/documentation/master/install/docker/opensuse-docker-install.md
+
+Please download this file and run kata-doc-to-script.sh again."
+```
+-->

--- a/install/docker/opensuse-tumbleweed-docker-install.md
+++ b/install/docker/opensuse-tumbleweed-docker-install.md
@@ -1,0 +1,14 @@
+# Install Docker for Kata Containers on openSUSE Tumbleweed
+
+Follow the instructions in the generic [openSUSE Docker install guide](opensuse-docker-install.md).
+<!--
+You can ignore the content of this comment.
+(test code run by test-install-docs.sh to validate code blocks this document)
+
+```bash
+$ echo "NOTE: this document is just a link to the generic openSUSE install guide located at:
+https://raw.githubusercontent.com/kata-containers/documentation/master/install/docker/opensuse-docker-install.md
+
+Please download this file and run kata-doc-to-script.sh again."
+```
+-->

--- a/install/opensuse-installation-guide.md
+++ b/install/opensuse-installation-guide.md
@@ -1,4 +1,4 @@
-# Install Kata Containers on openSUSE Leap/Tumbleweed
+# Install Kata Containers on openSUSE
 
 1. Install the Kata Containers components with the following commands:
 
@@ -18,6 +18,5 @@
    ```
 
 2. Decide which container manager to use and select the corresponding link that follows:
-
    - [Docker](docker/opensuse-docker-install.md)
-   - [Kubernetes](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#run-kata-containers-with-kubernetes)
+   - [Kubernetes](../Developer-Guide.md#run-kata-containers-with-kubernetes)

--- a/install/opensuse-installation-guide.md
+++ b/install/opensuse-installation-guide.md
@@ -1,13 +1,20 @@
-# Install Kata Containers on openSUSE Leap
+# Install Kata Containers on openSUSE Leap/Tumbleweed
 
 1. Install the Kata Containers components with the following commands:
 
    ```bash
    $ source /etc/os-release
+   $ DISTRO_REPO=$(sed "s/ /_/g" <<< "$NAME")
+   $ [ -n "$VERSION" ] && DISTRO_REPO+="_${VERSION}"
    $ ARCH=$(arch)
    $ BRANCH="${BRANCH:-master}"
-   $ sudo -E zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/${BRANCH}/openSUSE_Leap_${VERSION_ID}/home:katacontainers:releases:${ARCH}:${BRANCH}.repo"
-   $ sudo -E zypper -n --no-gpg-checks install kata-runtime kata-proxy kata-shim
+   $ REPO_ALIAS="kata-${BRANCH}"
+   $ PUBKEY="/tmp/rpm-signkey.pub"
+   $ curl -SsL -o "$PUBKEY" "https://raw.githubusercontent.com/kata-containers/tests/master/data/rpm-signkey.pub"
+   $ sudo -E rpm --import "$PUBKEY"
+   $ zypper lr "$REPO_ALIAS" && sudo -E zypper -n removerepo "$REPO_ALIAS"
+   $ sudo -E zypper addrepo --refresh "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/${BRANCH}/${DISTRO_REPO}/" "$REPO_ALIAS"
+   $ sudo -E zypper -n install kata-runtime
    ```
 
 2. Decide which container manager to use and select the corresponding link that follows:

--- a/install/opensuse-leap-installation-guide.md
+++ b/install/opensuse-leap-installation-guide.md
@@ -1,0 +1,14 @@
+# Install Kata Containers on openSUSE Leap
+
+Follow the instructions in the generic [openSUSE install guide](opensuse-installation-guide.md).
+<!--
+You can ignore the content of this comment.
+(test code run by test-install-docs.sh to validate code blocks this document)
+
+```bash
+$ echo "NOTE: this document is just a link to the generic openSUSE install guide located at:
+https://raw.githubusercontent.com/kata-containers/documentation/master/install/opensuse-installation-guide.md
+
+Please download this file and run kata-doc-to-script.sh again."
+```
+-->

--- a/install/opensuse-leap-installation-guide.md
+++ b/install/opensuse-leap-installation-guide.md
@@ -1,6 +1,7 @@
 # Install Kata Containers on openSUSE Leap
 
-Follow the instructions in the generic [openSUSE install guide](opensuse-installation-guide.md).
+1. Install Kata Containers on openSUSE by following the instructions in the
+[openSUSE install guide](opensuse-installation-guide.md).
 <!--
 You can ignore the content of this comment.
 (test code run by test-install-docs.sh to validate code blocks this document)
@@ -12,3 +13,7 @@ https://raw.githubusercontent.com/kata-containers/documentation/master/install/o
 Please download this file and run kata-doc-to-script.sh again."
 ```
 -->
+
+2. Decide which container manager to use and select the corresponding link that follows:
+   - [Docker](docker/opensuse-leap-docker-install.md)
+   - [Kubernetes](../Developer-Guide.md#run-kata-containers-with-kubernetes)

--- a/install/opensuse-tumbleweed-installation-guide.md
+++ b/install/opensuse-tumbleweed-installation-guide.md
@@ -1,6 +1,7 @@
 # Install Kata Containers on openSUSE Tumbleweed
 
-Follow the instructions in the generic [openSUSE install guide](opensuse-installation-guide.md).
+1. Install Kata Containers on openSUSE by following the instructions in the
+[openSUSE install guide](opensuse-installation-guide.md).
 <!--
 You can ignore the content of this comment.
 (test code run by test-install-docs.sh to validate code blocks this document)
@@ -12,3 +13,7 @@ https://raw.githubusercontent.com/kata-containers/documentation/master/install/o
 Please download this file and run kata-doc-to-script.sh again."
 ```
 -->
+
+2. Decide which container manager to use and select the corresponding link that follows:
+   - [Docker](docker/opensuse-tumbleweed-docker-install.md)
+   - [Kubernetes](../Developer-Guide.md#run-kata-containers-with-kubernetes)

--- a/install/opensuse-tumbleweed-installation-guide.md
+++ b/install/opensuse-tumbleweed-installation-guide.md
@@ -1,0 +1,14 @@
+# Install Kata Containers on openSUSE Tumbleweed
+
+Follow the instructions in the generic [openSUSE install guide](opensuse-installation-guide.md).
+<!--
+You can ignore the content of this comment.
+(test code run by test-install-docs.sh to validate code blocks this document)
+
+```bash
+$ echo "NOTE: this document is just a link to the generic openSUSE install guide located at:
+https://raw.githubusercontent.com/kata-containers/documentation/master/install/opensuse-installation-guide.md
+
+Please download this file and run kata-doc-to-script.sh again."
+```
+-->


### PR DESCRIPTION
    Support installing kata packages on all openSUSE distros.
    
Fixes: #483

And also:
    install: improve Docker installation for openSUSE
    
    Editing systemd unit files to customize Docker for Kata may generate conflicts
    with what's specified in /etc/sysconfig/docker, so use that file directly.
    
    Also, libcgroup1 dependency is wrong for newer distros, and should be
    pulled automatically for older ones.