### PR TITLE
debug: Add coreutils to the list of packages for debug console.

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -652,14 +652,15 @@ the following steps, which assume the use of a rootfs image.
 
 To login to a virtual machine, you must
 [create a custom rootfs](#create-a-rootfs-image)
-containing a shell such as `bash(1)`.
+containing a shell such as `bash(1)`. For Clear Linux, you will need
+an additional `coreutils` package.
 
 For example using CentOS:
 
 ```
 $ cd $GOPATH/src/github.com/kata-containers/osbuilder/rootfs-builder
 $ export ROOTFS_DIR=${GOPATH}/src/github.com/kata-containers/osbuilder/rootfs-builder/rootfs
-$ script -fec 'sudo -E GOPATH=$GOPATH USE_DOCKER=true EXTRA_PKGS="bash" ./rootfs.sh centos'
+$ script -fec 'sudo -E GOPATH=$GOPATH USE_DOCKER=true EXTRA_PKGS="bash coreutils" ./rootfs.sh centos'
 ```
 
 ### Create a debug systemd service


### PR DESCRIPTION
This package is not installed with systemd in Clear. Add this
as an additional package requirement for debug console to make it
possible to debug.
This package contains utilties like `cat`, `ls`, `echo` etc required
for a useful debug.

Fixes #302

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>