### PR TITLE
docs: Fix workaround solution for ConfigPath

### DIFF
--- a/how-to/containerd-kata.md
+++ b/how-to/containerd-kata.md
@@ -204,7 +204,7 @@ shell script with the following:
 
 ```bash
 #!/bin/bash
-KATA_CONF_FILE=/etc/kata-containers/firecracker.toml containerd-shim-kata-v2
+KATA_CONF_FILE=/etc/kata-containers/firecracker.toml containerd-shim-kata-v2 $@
 ```
 
 Name it as `/usr/local/bin/containerd-shim-katafc-v2` and reference it in the configuration of containerd:


### PR DESCRIPTION
In the workaround solution of ConfigPath, there is a '$@'
missing in the script, so add it.

Fixes: #515

Signed-off-by: Chengguang Xu <cgxu519@zoho.com.cn>