### PR TITLE
docs: Add static installation guide

### DIFF
--- a/.ci/test-install-docs.sh
+++ b/.ci/test-install-docs.sh
@@ -162,6 +162,7 @@ test_distro_install_guide()
 #
 # - kata-manager ("Automatic" method).
 # - kata-doc-to-script ("Scripted" method).
+# - "Static" method.
 #
 # Testing these is awkward because we need to "execute" the documents
 # describing those install methods, but since those install methods should
@@ -178,6 +179,7 @@ test_alternative_install_methods()
 	local -a files
 	files+=("installing-with-kata-manager.md")
 	files+=("installing-with-kata-doc-to-script.md")
+	files+=("installing-kata-static-binaries.md")
 
 	local tmp_dir
 

--- a/install/README.md
+++ b/install/README.md
@@ -34,6 +34,7 @@ to see if your system is capable of running Kata Containers.
 | [Using official distro packages](#official-packages) |Kata packages provided by Linux distributions official repositories                      |[see table](#supported-distributions) |
 | [Scripted](#scripted-installation)                   |Generates an installation script which will result in a working system when executed     |[see table](#supported-distributions) |
 | [Manual](#manual-installation)                       |Allows the user to read a brief document and execute the specified commands step-by-step |[see table](#supported-distributions) |
+| [Static](#static-installation)                       |Cloud provisioning and quick evaluation. Not recommended for normal users.               |[see table](#supported-distributions) |
 
 ### Supported Distributions
 
@@ -70,6 +71,10 @@ Kata packages are provided by official distribution repositories for:
 
 ### Scripted Installation
 [Use `kata-doc-to-script`](installing-with-kata-doc-to-script.md) to generate installation scripts that can be reviewed before they are executed.
+
+### Static Installation
+
+See the [static installation guide](installing-kata-static-binaries.md).
 
 ### Manual Installation
 Manual installation instructions are available for [these distributions](#supported-distributions) and document how to:

--- a/install/docker/README.md
+++ b/install/docker/README.md
@@ -1,0 +1,13 @@
+# Kata Containers Docker install guides
+
+Select the install guide for your distribution:
+
+* [CentOS](centos-docker-install.md)
+* [Debian](debian-docker-install.md)
+* [Fedora](fedora-docker-install.md)
+* [OpenSUSE Leap](opensuse-leap-docker-install.md)
+* [OpenSUSE](opensuse-docker-install.md)
+* [OpenSUSE Tumbleweed](opensuse-tumbleweed-docker-install.md)
+* [RHEL](rhel-docker-install.md)
+* [SLES](sles-docker-install.md)
+* [Ubuntu](ubuntu-docker-install.md)

--- a/install/installing-kata-static-binaries.md
+++ b/install/installing-kata-static-binaries.md
@@ -1,0 +1,46 @@
+# Install Kata Containers static binaries
+
+* [Overview](#overview)
+* [Installation](#installation)
+
+# Overview
+
+Kata Containers is available as an archive file containing a set of static
+binaries. This alternative installation is useful for cloud provisioning
+systems which automatically pull the latest static binaries release.
+
+We recommend normal users install using the
+[automatic installation method](https://github.com/kata-containers/documentation/tree/master/install)
+unless they understand the full implications of installing using the static binaries.
+
+> **WARNING:**
+>
+> This installation method is **not** recommended for normal users since the
+> installation does not use the distribution package manager. This means new
+> versions of Kata Containers will **not** automatically install.
+
+# Installation
+
+1. Download the static binaries archive file with the following commands:
+
+   ```bash
+   $ arch=$(uname -m)
+   $ version=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/kata-containers/runtime/releases/latest | awk -F\/ '{print $NF}')
+   $ file="kata-static-${version}-${arch}.tar.xz"
+   $ url="https://github.com/kata-containers/runtime/releases/download/${version}/${file}"
+   $ curl -OL "$url"
+   ```
+
+1. Unpack the archive:
+
+   ```bash
+   $ sudo tar -C / -xvf "$file"
+   ```
+
+1. Configure Docker:
+
+   ```bash
+   $ sudo /opt/kata/share/scripts/kata-configure-docker.sh "$file"
+   ```
+
+1. Install [Docker](docker).


### PR DESCRIPTION
Add a document explaining how to (and why you would want to) install the
static version of Kata Containers.

Fixes: #470.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>