### PR TITLE
install: refresh installation guide README

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -1,14 +1,19 @@
 # Kata Containers installation user guides
 
-- [Prerequisites](#prerequisites)
-- [Installing on a Linux System](#installing-on-a-linux-system)
-    * [Automatic Installation](#automatic-installation)
-    * [Scripted Installation](#scripted-installation)
-    * [Manual Installation](#manual-installation)
-        + [Supported Distributions](#supported-distributions)
-    * [Snap Installation](#snap-installation)
-- [Installing on a Cloud Service Platform](#installing-on-a-cloud-service-platform)
-- [Further information](#further-information)
+* [Prerequisites](#prerequisites)
+* [Packaged installation methods](#packaged-installation-methods)
+   * [Supported Distributions](#supported-distributions)
+      * [Official packages](#official-packages)
+   * [Automatic Installation](#automatic-installation)
+   * [Snap Installation](#snap-installation)
+   * [Scripted Installation](#scripted-installation)
+   * [Manual Installation](#manual-installation)
+* [Build from source installation](#build-from-source-installation)
+* [Installing on a Cloud Service Platform](#installing-on-a-cloud-service-platform)
+* [Further information](#further-information)
+
+The following is an overview of the different installation methods available. All of these methods equally result
+in a system configured to run Kata Containers.
 
 ## Prerequisites
 Kata Containers requires nested virtualization or bare metal.
@@ -16,31 +21,52 @@ See the
 [hardware requirements](https://github.com/kata-containers/runtime/blob/master/README.md#hardware-requirements)
 to see if your system is capable of running Kata Containers.
 
-## Installing on a Linux System
-The following is an overview of the different installation methods available. All of these methods equally result
-in a system configured to run Kata Containers.
-
-
-| Installation method                                        | Suggested for               | Description                                                                                                                                 | Packaged install | Distributions supported               |
-|------------------------------------------------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|------------------|---------------------------------------|
-| [Automatic](#automatic-installation)                       | Quick start for new users   | Run a single command to install a full system.                                                                                              | yes              | [see table](#supported-distributions) |
-| [Manual](#manual-installation)                             | Self paced user install     | Allows the user to read a brief document and execute the specified commands step-by-step.                                                  | yes              | [see table](#supported-distributions) |
-| [Scripted](#scripted-installation)                         | Administrators              | Generates an installation script which will result in a working system when executed.                                                       | yes              | [see table](#supported-distributions) |
-| [Build from sources](../Developer-Guide.md#initial-setup) | Developers and hackers only | Allows power users who are comfortable building software from source to use the latest component versions. Not recommended for normal users. | no               | any distro                            |
-| [Using snap](#snap-installation)                           | Users and Administrators    | Easy to install and automatic updates                                                                                                       | yes              | any distro that supports snapd        |
+## Packaged installation methods
 
 > **Notes:**
 >
-> - The "Packaged install" column shows if the resulting installation
->   uses your distribution's native package format (such as RPM or DEB).
->
-> - Power users who decide to build from sources should be aware of the
->   implications of using an unpackaged system which will not be automatically
->   updated as new [releases](../Releases.md) are made available.
+> - Packaged installation methods uses your distribution's native package format (such as RPM or DEB).
+
+| Installation method                                  | Description                                                                             | Distributions supported              |
+|------------------------------------------------------|-----------------------------------------------------------------------------------------|--------------------------------------|
+| [Automatic](#automatic-installation)                 |Run a single command to install a full system                                            |[see table](#supported-distributions) |
+| [Using snap](#snap-installation)                     |Easy to install and automatic updates                                                    |any distro that supports snapd        |
+| [Using official distro packages](#official-packages) |Kata packages provided by Linux distributions official repositories                      |[see table](#supported-distributions) |
+| [Scripted](#scripted-installation)                   |Generates an installation script which will result in a working system when executed     |[see table](#supported-distributions) |
+| [Manual](#manual-installation)                       |Allows the user to read a brief document and execute the specified commands step-by-step |[see table](#supported-distributions) |
+
+### Supported Distributions
+
+Kata is packaged by the Kata community for:
+
+|Distribution (link to installation guide)                        | Versions                                                                                                          |
+|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+|[CentOS](centos-installation-guide.md)                           | 7                                                                                                                 |
+|[Debian](debian-installation-guide.md)                           | 9                                                                                                                 |
+|[Fedora](fedora-installation-guide.md)                           | 28, 29, 30                                                                                                        |
+|[openSUSE](opensuse-installation-guide.md)                       | [Leap](opensuse-leap-installation-guide.md) (15, 15.1)<br>[Tumbleweed](opensuse-tumbleweed-installation-guide.md) |
+|[Red Hat Enterprise Linux (RHEL)](rhel-installation-guide.md)    | 7                                                                                                                 |
+|[SUSE Linux Enterprise Server (SLES)](sles-installation-guide.md)| SLES 12 SP3                                                                                                       |
+|[Ubuntu](ubuntu-installation-guide.md)                           | 16.04, 18.04                                                                                                      |
+
+#### Official packages
+
+Kata packages are provided by official distribution repositories for:
+
+|Distribution (link to packages)                                  | Versions   |
+|-----------------------------------------------------------------|------------|
+|[openSUSE](https://software.opensuse.org/package/katacontainers) | Tumbleweed |
+
 
 ### Automatic Installation
 
 [Use `kata-manager`](installing-with-kata-manager.md) to automatically install Kata packages.
+
+### Snap Installation
+
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/kata-containers)
+
+[Use snap](snap-installation-guide.md) to install Kata Containers from https://snapcraft.io.
 
 ### Scripted Installation
 [Use `kata-doc-to-script`](installing-with-kata-doc-to-script.md) to generate installation scripts that can be reviewed before they are executed.
@@ -77,22 +103,16 @@ Manual installation instructions are available for [these distributions](#suppor
 > - Only trust the signing key and fingerprint listed in the previous bullet point. Do not disable GPG checks,
 > otherwise packages source and authenticity is not guaranteed.
 
-### Snap Installation
+## Build from source installation
+> **Notes:**
+>
+> - Power users who decide to build from sources should be aware of the
+>   implications of using an unpackaged system which will not be automatically
+>   updated as new [releases](../Releases.md) are made available.
 
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/kata-containers)
-
-[Use snap](snap-installation-guide.md) to install Kata Containers from https://snapcraft.io.
-
-#### Supported Distributions
-|Distro specific installation instructions                        | Versions                                                                                                          |
-|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-|[CentOS](centos-installation-guide.md)                           | 7                                                                                                                 |
-|[Debian](debian-installation-guide.md)                           | 9                                                                                                                 |
-|[Fedora](fedora-installation-guide.md)                           | 28, 29, 30                                                                                                        |
-|[openSUSE](opensuse-installation-guide.md)                       | [Leap](opensuse-leap-installation-guide.md) (42.3, 15)<br>[Tumbleweed](opensuse-tumbleweed-installation-guide.md) |
-|[Red Hat Enterprise Linux (RHEL)](rhel-installation-guide.md)    | 7                                                                                                                 |
-|[SUSE Linux Enterprise Server (SLES)](sles-installation-guide.md)| SLES 12 SP3                                                                                                       |
-|[Ubuntu](ubuntu-installation-guide.md)                           | 16.04, 18.04                                                                                                      |
+[Building from sources](../Developer-Guide.md#initial-setup)  allows power users
+who are comfortable building software from source to use the latest component
+versions. This is not recommended for normal users.
 
 ## Installing on a Cloud Service Platform
 * [Amazon Web Services (AWS)](aws-installation-guide.md)


### PR DESCRIPTION
Refresh installation guide README with a clearer structure, and provide
a list of distribution with official Kata packages. This also updates
the openSUSE Leap versions supported to 15 and 15.1.

Fixes: #533

Signed-off-by: Marco Vedovati <mvedovati@suse.com>