### PR TITLE
shimv2: Add instruction to pull image first

### DIFF
--- a/how-to/containerd-kata.md
+++ b/how-to/containerd-kata.md
@@ -326,6 +326,7 @@ debug: true
 To run a container with Kata Containers through the containerd command line, you can run the following:
 
 ```bash
+$ sudo ctr image pull docker.io/library/busybox:latest
 $ sudo ctr run --runtime io.containerd.run.kata.v2 -t --rm docker.io/library/busybox:latest hello sh
 ```
 


### PR DESCRIPTION
Running the container with `ctr` when the image is not present
on the system gives an error.

Fixes #536

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>