### PR TITLE
virtiofs: hugepages is no longer required since Kata 1.8

### DIFF
--- a/how-to/how-to-use-virtio-fs-with-kata.md
+++ b/how-to/how-to-use-virtio-fs-with-kata.md
@@ -21,7 +21,7 @@ This document describes how to get Kata Containers to work with virtio-fs.
 
 ## Pre-requisites
 
-* This feature currently requires the host to have hugepages support enabled. Enable this with the `sysctl vm.nr_hugepages=1024` command on the host.
+* Before Kata 1.8 this feature required the host to have hugepages support enabled. Enable this with the `sysctl vm.nr_hugepages=1024` command on the host.
 
 ## Install Kata Containers with virtio-fs support
 


### PR DESCRIPTION
The documentation says hugepages are required for virtio-fs.  This
limitation was removed in Kata 1.8 in kata-runtime commit
a41894da18310b9c14dd59da1e924f4938271d4f ("runtime: Enable file based
backend").

Fixes: #544
Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>