### PR TITLE
docs: Emphasise default docker config

### DIFF
--- a/install/docker/centos-docker-install.md
+++ b/install/docker/centos-docker-install.md
@@ -21,9 +21,10 @@
    For more information on installing Docker please refer to the
    [Docker Guide](https://docs.docker.com/engine/installation/linux/centos).
 
-2. Configure Docker to use Kata Containers by default with one of the following methods:
+2. Configure Docker to use Kata Containers by default with **ONE** of the following methods:
 
-   1. systemd
+   1. systemd (this is the default and is applied automatically if you select the
+      [automatic installation](https://github.com/kata-containers/documentation/tree/master/install#automatic-installation) option)
 
        ```bash
        $ sudo mkdir -p /etc/systemd/system/docker.service.d/

--- a/install/docker/debian-docker-install.md
+++ b/install/docker/debian-docker-install.md
@@ -25,7 +25,7 @@
    For more information on installing Docker please refer to the
    [Docker Guide](https://docs.docker.com/engine/installation/linux/debian).
 
-2. Configure Docker to use Kata Containers by default with ONE of the following methods:
+2. Configure Docker to use Kata Containers by default with **ONE** of the following methods:
 
 a. `sysVinit`
     
@@ -36,7 +36,8 @@ a. `sysVinit`
     DOCKER_OPTS=\"-D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime\"' >> /etc/default/docker"
     ```
     
-b. systemd
+b. systemd (this is the default and is applied automatically if you select the
+      [automatic installation](https://github.com/kata-containers/documentation/tree/master/install#automatic-installation) option)
 
     ```bash
     $ sudo mkdir -p /etc/systemd/system/docker.service.d/

--- a/install/docker/fedora-docker-install.md
+++ b/install/docker/fedora-docker-install.md
@@ -23,9 +23,10 @@
    For more information on installing Docker please refer to the
    [Docker Guide](https://docs.docker.com/engine/installation/linux/fedora).
 
-2. Configure Docker to use Kata Containers by default with one of the following methods:
+2. Configure Docker to use Kata Containers by default with **ONE** of the following methods:
 
-   1. systemd
+   1. systemd (this is the default and is applied automatically if you select the
+      [automatic installation](https://github.com/kata-containers/documentation/tree/master/install#automatic-installation) option)
 
        ```bash
        $ sudo mkdir -p /etc/systemd/system/docker.service.d/

--- a/install/docker/opensuse-docker-install.md
+++ b/install/docker/opensuse-docker-install.md
@@ -20,9 +20,10 @@
    For more information on installing Docker please refer to the
    [Docker Guide](https://software.opensuse.org/package/docker).
 
-2. Configure the Docker daemon to use Kata Containers by default, with one of the following methods:
+2. Configure Docker to use Kata Containers by default with **ONE** of the following methods:
 
-   1. Specify the runtime options in `/etc/sysconfig/docker`:
+   1. Specify the runtime options in `/etc/sysconfig/docker` (this is the default and is applied automatically if you select the
+      [automatic installation](https://github.com/kata-containers/documentation/tree/master/install#automatic-installation) option)
 
        ```bash
        $ DOCKER_SYSCONFIG=/etc/sysconfig/docker

--- a/install/docker/rhel-docker-install.md
+++ b/install/docker/rhel-docker-install.md
@@ -22,9 +22,10 @@
    For more information on installing Docker please refer to the
    [Docker Guide](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/getting_started_with_containers/#getting_docker_in_rhel_7).
 
-2. Configure Docker to use Kata Containers by default with one of the following methods:
+2. Configure Docker to use Kata Containers by default with **ONE** of the following methods:
 
-   1. systemd
+   1. systemd (this is the default and is applied automatically if you select the
+      [automatic installation](https://github.com/kata-containers/documentation/tree/master/install#automatic-installation) option)
 
        ```bash
        $ sudo mkdir -p /etc/systemd/system/docker.service.d/

--- a/install/docker/sles-docker-install.md
+++ b/install/docker/sles-docker-install.md
@@ -20,9 +20,10 @@
    For more information on installing Docker please refer to the
    [Docker Guide](https://www.suse.com/documentation/sles-12/singlehtml/book_sles_docker/book_sles_docker.html).
 
-2. Configure Docker to use Kata Containers by default with one of the following methods:
+2. Configure Docker to use Kata Containers by default with **ONE** of the following methods:
 
-   1. systemd
+   1. systemd (this is the default and is applied automatically if you select the
+      [automatic installation](https://github.com/kata-containers/documentation/tree/master/install#automatic-installation) option)
 
        ```bash
        $ sudo mkdir -p /etc/systemd/system/docker.service.d/

--- a/install/docker/ubuntu-docker-install.md
+++ b/install/docker/ubuntu-docker-install.md
@@ -25,9 +25,10 @@
    For more information on installing Docker please refer to the
    [Docker Guide](https://docs.docker.com/engine/installation/linux/ubuntu).
 
-2. Configure Docker to use Kata Containers by default with one of the following methods:
+2. Configure Docker to use Kata Containers by default with **ONE** of the following methods:
 
-   1. systemd
+   1. systemd (this is the default and is applied automatically if you select the
+      [automatic installation](https://github.com/kata-containers/documentation/tree/master/install#automatic-installation) option)
 
        ```bash
        $ sudo mkdir -p /etc/systemd/system/docker.service.d/


### PR DESCRIPTION
Improved the Docker installation instructions by making it clear *which* of the multiple ways of configuration Docker for Kata is the default, and that it is not necessary to do anything further if users select the automatic installation method.

Fixes: #551.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>