### PR TITLE
docs: daemon.json in Server Version Docker: 18.09.0  > * (Fedora 27) Not required.

### DIFF
--- a/install/docker/fedora-docker-install.md
+++ b/install/docker/fedora-docker-install.md
@@ -37,7 +37,8 @@
        ```
 
    2. Docker `daemon.json` 
-      *If you are using Server Version: 18.09.0 > ignore this step.*
+   
+      **If you are using Server Version: 18.09.0 > ignore this step.**
 
        Add the following definitions to `/etc/docker/daemon.json`:
 

--- a/install/docker/fedora-docker-install.md
+++ b/install/docker/fedora-docker-install.md
@@ -36,7 +36,7 @@
        EOF
        ```
 
-   2. Docker `daemon.json`
+   2. Docker `daemon.json` If you are using Server Version: 18.09.0 > this ignore this step.
 
        Add the following definitions to `/etc/docker/daemon.json`:
 

--- a/install/docker/fedora-docker-install.md
+++ b/install/docker/fedora-docker-install.md
@@ -36,7 +36,8 @@
        EOF
        ```
 
-   2. Docker `daemon.json` If you are using Server Version: 18.09.0 > this ignore this step.
+   2. Docker `daemon.json` 
+      *If you are using Server Version: 18.09.0 > ignore this step.*
 
        Add the following definitions to `/etc/docker/daemon.json`:
 


### PR DESCRIPTION
Follow the guide steps for Fedora, I could not run Docker with Kata Engine.

Throws me this error:

```bash
Redirecting to /bin/systemctl status  -l docker.service
● docker.service - Docker Application Container Engine
   Loaded: loaded (/usr/lib/systemd/system/docker.service; disabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/docker.service.d
           └─kata-containers.conf
   Active: failed (Result: exit-code) since Wed 2019-09-18 15:39:47 CDT; 1min 8s ago
     Docs: https://docs.docker.com
  Process: 16297 ExecStart=/usr/bin/dockerd -D --add-runtime kata-runtime=/usr/bin/kata-runtime --default-runtime=kata-runtime (code=exited, status=1/FAILURE)
 Main PID: 16297 (code=exited, status=1/FAILURE)

Sep 18 15:39:45 zatory systemd[1]: Failed to start Docker Application Container Engine.
Sep 18 15:39:47 zatory systemd[1]: docker.service: Service hold-off time over, scheduling restart.
Sep 18 15:39:47 zatory systemd[1]: docker.service: Scheduled restart job, restart counter is at 3.
Sep 18 15:39:47 zatory systemd[1]: Stopped Docker Application Container Engine.
Sep 18 15:39:47 zatory systemd[1]: docker.service: Start request repeated too quickly.
Sep 18 15:39:47 zatory systemd[1]: docker.service: Failed with result 'exit-code'.
Sep 18 15:39:47 zatory systemd[1]: Failed to start Docker Application Container Engine.
Sep 18 15:40:29 zatory systemd[1]: docker.service: Start request repeated too quickly.
Sep 18 15:40:29 zatory systemd[1]: docker.service: Failed with result 'exit-code'.
Sep 18 15:40:29 zatory systemd[1]: Failed to start Docker Application Container Engine.
```
I think the problem is because, in the lastest Server Version Docker, daemon.json works in a different way. So, only I needed delete daemon.json, is enough configure service.


