### PR TITLE
Add podman docs

### DIFF
--- a/how-to/README.md
+++ b/how-to/README.md
@@ -23,3 +23,4 @@
 - [What Is VM Templating and How To Enable It](what-is-vm-templating-and-how-do-I-use-it.md)
 - [Privileged Kata Containers](privileged.md)
 - [How to load kernel modules in Kata Containers](how-to-load-kernel-modules-with-kata.md)
+- [Rootless Kata Containers](how-to-use-rootless-kata-containers-with-podman.md)

--- a/how-to/how-to-use-rootless-kata-containers-with-podman.md
+++ b/how-to/how-to-use-rootless-kata-containers-with-podman.md
@@ -1,0 +1,171 @@
+# How to use rootless Kata Containers with Podman
+
+* [How to use rootless Kata Containers with Podman](#how-to-use-rootless-kata-containers-with-podman)
+    * [Requirements](#requirements)
+    * [Installation](#installation)
+    * [Configuration](#configuration)
+            * [1. Disable SELinux](#1-disable-selinux)
+            * [2. Add user to KVM group](#2-add-user-to-kvm-group)
+            * [3. Reboot](#3-reboot)
+            * [5. Disable `vhost-net`](#5-disable-vhost-net)
+            * [6. Modify the Kata images permissions](#6-modify-the-kata-images-permissions)
+            * [7. Set up Podman rootless configuration](#7-set-up-podman-rootless-configuration)
+            * [8. Add Kata Runtime to Podman configuration file (optional)](#8-add-kata-runtime-to-podman-configuration-file-optional)
+            * [9. Set Kata runtime as Podman's default OCI runtime (optional)](#9-set-kata-runtime-as-podmans-default-oci-runtime-optional)
+    * [Run Kata with rootless Podman](#run-kata-with-rootless-podman)
+    * [Appendix: Possible Errors](#appendix-possible-errors)
+        * [Error caused by agent or runtime version mismatch](#error-caused-by-agent-or-runtime-version-mismatch)
+        * [Missing registry file](#missing-registry-file)
+
+
+For an even more secure system, [Kata Containers](https://Katacontainers.io) can run workloads without a privileged user. Using [Podman](https://podman.io/) as the container engine, and [slirp4netns](https://github.com/rootless-containers/slirp4netns) for user-space networking.
+
+## Requirements
+- A Linux system, see [supported distributions](https://github.com/kata-containers/documentation/blob/master/install/README.md#supported-distributions) for an updated list.
+  - If using CentOS 7, `newuidmap` and `newgidmap` do not exist, and can be installed with:
+    ``` bash
+    $ (git clone https://github.com/shadow-maint/shadow; cd shadow; ./autogen.sh --prefix=/usr --enable-man; make && sudo make -C src install)
+    $ sudo bash -c 'echo 10000 > /proc/sys/user/max_user_namespaces'
+    $ sudo bash -c "echo $(whoami):110000:65536 > /etc/subuid"
+    $ sudo bash -c "echo $(whoami):110000:65536 > /etc/subgid"
+    ```
+- Golang 1.12
+
+## Installation
+Refer to the following table for the __minimum__ required software versions and the installation instructions:
+
+| Component       | Version | Install Instructions|
+| ----------------|:-------:|---------------------|
+| Podman          | WIP     | [see here](https://github.com/containers/libpod/blob/master/install.md)
+| slirp4netns     | 0.4.0   | [see here](https://github.com/rootless-containers/slirp4netns#quick-start)
+| Kata Containers | WIP     | [see here](https://github.com/kata-containers/documentation/blob/master/install/README.md)
+
+> **NOTE:**
+> If installing Podman with a package manager, there is usually no need to install slirp4netns separately.
+
+## Configuration
+Now that Kata Containers and Podman have been installed, they need to be configured for rootless execution.
+
+#### 1. Disable SELinux
+If SELinux is installed and enabled, it needs to be disabled with the following command (Kata Containers [does not support SELinux](https://github.com/kata-containers/documentation/blob/master/Limitations.md#selinux-support)).
+
+> **Warning:**
+> The following command may differ depending on the distro being used:
+
+```bash
+$ [ -f /etc/selinux/config ] && sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/selinux/config
+```
+
+#### 2. Add user to KVM group
+If running a KVM based hypervisor, the user running the workload needs to be added to the KVM group:
+```bash
+$ sudo usermod -a -G kvm $USER
+```
+
+#### 3. Reboot
+Reboot the system for the changes to take effect (a reboot is required when disabling SELinux, while logging out and back in is enough to have that user joining the `KVM` group).
+
+You can now verify if the configuration is correct:
+
+* (if installed) SELinux should have been disabled:
+```bash
+$ getenforce
+Disabled
+```
+
+* The user should be in the `kvm` group:
+```
+$ groups | grep -ow kvm
+kvm
+```
+
+#### 4. Setup Kata configuration files
+If the Kata `configuration.toml` file does not exist in `/etc`, do the following:
+```bash
+$ sudo install -D -o ${USER} -g root -m 0640 /usr/share/defaults/kata-containers/configuration.toml /etc/kata-containers
+```
+
+Or, if the file exists, but is not readable by the user:
+```bash
+$ sudo chown -R a+r /etc/kata-containers/
+```
+
+#### 5. Disable `vhost-net`
+Disable `vhost-net` in the Kata configuration file, by commenting out the `disable_vhost_net` line:
+```bash
+$ sudo sed -i -e 's/^#disable_vhost_net = true/disable_vhost_net = true/' /etc/kata-containers/configuration.toml
+```
+
+#### 6. Modify the Kata images permissions
+The Kata images needs to be accessible by the user, so change the permissions of the image directory to be readable by the user.
+```bash
+$ sudo chown -R a+r /usr/share/kata-containers
+```
+
+#### 7. Set up Podman rootless configuration
+If `libpod.conf` does not exist in `~/.config/containers/`:
+```bash
+$ sudo install -D -o ${USER} -g ${USER} -m 0640 /usr/share/containers/libpod.conf ~/.config/containers/
+```
+
+By default the `tmp_dir` in `libpod.conf` is set to `/var/run/libpod`, however that is not accessible by a user, so change to the rootless runtime directory.
+```bash
+$ sed -i -e "s|^tmp_dir = .*$|tmp_dir = \"$XDG_RUNTIME_DIR/libpod/tmp\"|" ~/.config/containers/libpod.conf
+```
+
+#### 8. Add Kata Runtime to Podman configuration file (optional)
+You can tell Podman to create or run containers using the Kata runtime with `--runtime=value` flag.
+
+You can directly pass the fully qualified Kata runtime path with:
+```bash
+$ podman run --runtime=/usr/local/bin/kata-runtime ...
+```
+
+or add a `kata` entry in the `[runtimes]` section of the configuration file by appending the Kata Runtime binary path(s) to the `libpod.conf` file:
+```bash
+$ echo 'kata = ["/usr/local/bin/kata-runtime"]' >> ~/.config/containers/libpod.conf
+```
+and then use `kata` as the runtime name:
+```bash
+$ podman run --runtime=kata ...
+```
+
+> **NOTE:**
+> A less recommended approach could be to have the absolute `kata-runtime` path in the standard `$PATH` location instead of the configuration file, and a binary with that name will be looked up automatically:
+```bash
+kata-runtime = [
+]
+```
+
+#### 9. Set Kata runtime as Podman's default OCI runtime (optional)
+To avoid using the `--runtime=value` flag set Kata runtime as the default runtime:
+```bash
+$ sed -i -e 's/^runtime = "runc"/runtime = "kata"/' ~/.config/containers/libpod.conf
+```
+
+## Run Kata with rootless Podman
+```bash
+$ podman run --rm --runtime=kata alpine date
+```
+
+> **NOTE:**
+> To obtain debug logs you can:
+>  - Enable [debug](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#enable-full-debug) in Kata (logs are added to journald).
+>  - Pass `--log-level=debug` to Podman (logs are printed to stderr).
+
+## Appendix: Possible Errors
+If you are building from source you may encounter the following errors.
+
+### Error caused by agent or runtime version mismatch
+```
+rpc error: code = Internal desc = Could not add route dest()/gw(10.0.2.2)/dev(tap0): network is unreachable: OCI runtime error
+```
+Solution:
+You may need to [rebuild the agent](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#add-a-custom-agent-to-the-image---optional); there was a change in both the [agent](https://github.com/kata-containers/agent/commit/a78e8cfda627cc350dc9d9ca9b969ebb642030c3) and [runtime](https://github.com/kata-containers/runtime/commit/cfedb06a19135e2ab4f18203a4f3147cdc3a4980) code. This would probably only occur if building latest from source, since the runtime version would have the change and the released agent does not.
+
+### Missing registry file
+```
+Error: unable to pull alpine: image name provided is a short name and no search registries are defined in the registries config file.
+```
+Solution:
+The `/etc/containers/registries.conf` file is missing; either use the full image name, or add the [configuration file](https://github.com/containers/libpod/blob/master/install.md#configuration-files).

--- a/how-to/how-to-use-rootless-kata-containers-with-podman.md
+++ b/how-to/how-to-use-rootless-kata-containers-with-podman.md
@@ -62,6 +62,10 @@ them for rootless execution.
 
 ### Disable SELinux
 
+> **Warning:**
+>
+> You should understand the security implications before disabling SELinux.
+
 If SELinux is installed and enabled, it needs to be disabled with the
 following command (Kata Containers
 [does not support SELinux](https://github.com/kata-containers/documentation/blob/master/Limitations.md#selinux-support)).

--- a/how-to/how-to-use-rootless-kata-containers-with-podman.md
+++ b/how-to/how-to-use-rootless-kata-containers-with-podman.md
@@ -87,7 +87,6 @@ $ sudo usermod -a -G kvm $USER
 
 ### Reboot
 
-
 Reboot the system for the changes to take effect (when you disable SELinux you
 must reboot, while logging out and back in is enough to have that user joining
 the `kvm` group).

--- a/how-to/how-to-use-rootless-kata-containers-with-podman.md
+++ b/how-to/how-to-use-rootless-kata-containers-with-podman.md
@@ -4,19 +4,17 @@
     * [Requirements](#requirements)
     * [Installation](#installation)
     * [Configuration](#configuration)
-            * [1. Disable SELinux](#1-disable-selinux)
-            * [2. Add user to KVM group](#2-add-user-to-kvm-group)
-            * [3. Reboot](#3-reboot)
-            * [5. Disable `vhost-net`](#5-disable-vhost-net)
-            * [6. Modify the Kata images permissions](#6-modify-the-kata-images-permissions)
-            * [7. Set up Podman rootless configuration](#7-set-up-podman-rootless-configuration)
-            * [8. Add Kata Runtime to Podman configuration file (optional)](#8-add-kata-runtime-to-podman-configuration-file-optional)
-            * [9. Set Kata runtime as Podman's default OCI runtime (optional)](#9-set-kata-runtime-as-podmans-default-oci-runtime-optional)
+        * [Disable SELinux](#disable-selinux)
+        * [Add user to KVM group](#add-user-to-kvm-group)
+        * [Reboot](#reboot)
+        * [Disable `vhost-net`](#disable-vhost-net)
+        * [Modify the Kata images permissions](#modify-the-kata-images-permissions)
+        * [Set up Podman rootless configuration](#set-up-podman-rootless-configuration)
+        * [Add Kata Runtime to Podman configuration file (optional)](#add-kata-runtime-to-podman-configuration-file-optional)
     * [Run Kata with rootless Podman](#run-kata-with-rootless-podman)
     * [Appendix: Possible Errors](#appendix-possible-errors)
         * [Error caused by agent or runtime version mismatch](#error-caused-by-agent-or-runtime-version-mismatch)
         * [Missing registry file](#missing-registry-file)
-
 
 For an even more secure system, [Kata Containers](https://Katacontainers.io)
 can run workloads without a privileged user. Using
@@ -30,7 +28,7 @@ user-space networking.
   [supported distributions](https://github.com/kata-containers/documentation/blob/master/install/README.md#supported-distributions)
   for an updated list.
 
-  - If using CentOS 7, `newuidmap` and `newgidmap` do not exist, and can be installed with:
+  - If using CentOS 7, `newuidmap` and `newgidmap` do not exist. Install them with:
 
     ```bash
     $ (git clone https://github.com/shadow-maint/shadow; cd shadow; ./autogen.sh --prefix=/usr --enable-man; make && sudo make -C src install)
@@ -59,8 +57,8 @@ and the installation instructions:
 
 ## Configuration
 
-Now that Kata Containers and Podman have been installed, they need to be
-configured for rootless execution.
+Now that you have installed Kata Containers and Podman, you need to configure
+them for rootless execution.
 
 ### Disable SELinux
 
@@ -69,7 +67,7 @@ following command (Kata Containers
 [does not support SELinux](https://github.com/kata-containers/documentation/blob/master/Limitations.md#selinux-support)).
 
 > **Warning:**
-> The following command may differ depending on the distro being used:
+> The following command might differ depending on the distro you use:
 
 ```bash
 $ [ -f /etc/selinux/config ] && sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/selinux/config
@@ -77,7 +75,7 @@ $ [ -f /etc/selinux/config ] && sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /
 
 ### Add user to KVM group
 
-If running a KVM based hypervisor, the user running the workload needs to be added to the KVM group:
+If running a KVM based hypervisor, add the user running the workload to the KVM group:
 
 ```bash
 $ sudo usermod -a -G kvm $USER
@@ -85,23 +83,25 @@ $ sudo usermod -a -G kvm $USER
 
 ### Reboot
 
-Reboot the system for the changes to take effect (a reboot is required when
-disabling SELinux, while logging out and back in is enough to have that user
-joining the `KVM` group).
 
-You can now verify if the configuration is correct:
+Reboot the system for the changes to take effect (when you disable SELinux you
+must reboot, while logging out and back in is enough to have that user joining
+the `kvm` group).
 
-* (if installed) SELinux should have been disabled:
-```bash
-$ getenforce
-Disabled
-```
+Verify the configuration is correct:
 
-* The user should be in the `kvm` group:
-```
-$ groups | grep -ow kvm
-kvm
-```
+- If installed, disable SELinux:
+  ```bash
+  $ getenforce
+  Disabled
+  ```
+
+- The user should be in the `kvm` group:
+
+  ```
+  $ groups | grep -ow kvm
+  kvm
+  ```
 
 ### Setup Kata configuration files
 
@@ -178,8 +178,8 @@ $ podman run --runtime=kata ...
 > **NOTE:**
 >
 > A less recommended approach could be to have the absolute `kata-runtime`
-> path in the standard `$PATH` location instead of the configuration file, and
-> a binary with that name will be looked up automatically:
+> path in the standard `$PATH` location instead of the configuration file. In
+> this case it looks up a binary with that name automatically:
 >
 > ```bash
 > kata-runtime = [
@@ -207,13 +207,13 @@ $ podman run --rm --runtime=kata alpine date
 >
 >  - Enable
 >    [debug](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#enable-full-debug)
->    in Kata (logs are added to journald).
+>    in Kata (this adds the logs to journald).
 >
->  - Pass `--log-level=debug` to Podman (logs are printed to stderr).
+>  - Pass `--log-level=debug` to Podman (this prints the logs to stderr).
 
 ## Appendix: Possible Errors
 
-If you are building from source you may encounter the following errors.
+If you are building from source you might encounter the following errors.
 
 ### Error caused by agent or runtime version mismatch
 
@@ -223,7 +223,7 @@ rpc error: code = Internal desc = Could not add route dest()/gw(10.0.2.2)/dev(ta
 
 **Solution:**
 
-You may need to
+You might need to
 [rebuild the agent](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#add-a-custom-agent-to-the-image---optional);
 there was a change in both the
 [agent](https://github.com/kata-containers/agent/commit/a78e8cfda627cc350dc9d9ca9b969ebb642030c3)

--- a/how-to/how-to-use-rootless-kata-containers-with-podman.md
+++ b/how-to/how-to-use-rootless-kata-containers-with-podman.md
@@ -18,36 +18,55 @@
         * [Missing registry file](#missing-registry-file)
 
 
-For an even more secure system, [Kata Containers](https://Katacontainers.io) can run workloads without a privileged user. Using [Podman](https://podman.io/) as the container engine, and [slirp4netns](https://github.com/rootless-containers/slirp4netns) for user-space networking.
+For an even more secure system, [Kata Containers](https://Katacontainers.io)
+can run workloads without a privileged user. Using
+[Podman](https://podman.io/) as the container engine, and
+[`slirp4netns`](https://github.com/rootless-containers/slirp4netns) for
+user-space networking.
 
 ## Requirements
-- A Linux system, see [supported distributions](https://github.com/kata-containers/documentation/blob/master/install/README.md#supported-distributions) for an updated list.
+
+- A Linux system, see
+  [supported distributions](https://github.com/kata-containers/documentation/blob/master/install/README.md#supported-distributions)
+  for an updated list.
+
   - If using CentOS 7, `newuidmap` and `newgidmap` do not exist, and can be installed with:
-    ``` bash
+
+    ```bash
     $ (git clone https://github.com/shadow-maint/shadow; cd shadow; ./autogen.sh --prefix=/usr --enable-man; make && sudo make -C src install)
     $ sudo bash -c 'echo 10000 > /proc/sys/user/max_user_namespaces'
     $ sudo bash -c "echo $(whoami):110000:65536 > /etc/subuid"
     $ sudo bash -c "echo $(whoami):110000:65536 > /etc/subgid"
     ```
+
 - Golang 1.12
 
 ## Installation
-Refer to the following table for the __minimum__ required software versions and the installation instructions:
+
+Refer to the following table for the __minimum__ required software versions
+and the installation instructions:
 
 | Component       | Version | Install Instructions|
 | ----------------|:-------:|---------------------|
 | Podman          | WIP     | [see here](https://github.com/containers/libpod/blob/master/install.md)
-| slirp4netns     | 0.4.0   | [see here](https://github.com/rootless-containers/slirp4netns#quick-start)
+| `slirp4netns`   | 0.4.0   | [see here](https://github.com/rootless-containers/slirp4netns#quick-start)
 | Kata Containers | WIP     | [see here](https://github.com/kata-containers/documentation/blob/master/install/README.md)
 
 > **NOTE:**
-> If installing Podman with a package manager, there is usually no need to install slirp4netns separately.
+>
+> If installing Podman with a package manager, there is usually no need to
+> install `slirp4netns` separately.
 
 ## Configuration
-Now that Kata Containers and Podman have been installed, they need to be configured for rootless execution.
 
-#### 1. Disable SELinux
-If SELinux is installed and enabled, it needs to be disabled with the following command (Kata Containers [does not support SELinux](https://github.com/kata-containers/documentation/blob/master/Limitations.md#selinux-support)).
+Now that Kata Containers and Podman have been installed, they need to be
+configured for rootless execution.
+
+### Disable SELinux
+
+If SELinux is installed and enabled, it needs to be disabled with the
+following command (Kata Containers
+[does not support SELinux](https://github.com/kata-containers/documentation/blob/master/Limitations.md#selinux-support)).
 
 > **Warning:**
 > The following command may differ depending on the distro being used:
@@ -56,14 +75,19 @@ If SELinux is installed and enabled, it needs to be disabled with the following 
 $ [ -f /etc/selinux/config ] && sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/selinux/config
 ```
 
-#### 2. Add user to KVM group
+### Add user to KVM group
+
 If running a KVM based hypervisor, the user running the workload needs to be added to the KVM group:
+
 ```bash
 $ sudo usermod -a -G kvm $USER
 ```
 
-#### 3. Reboot
-Reboot the system for the changes to take effect (a reboot is required when disabling SELinux, while logging out and back in is enough to have that user joining the `KVM` group).
+### Reboot
+
+Reboot the system for the changes to take effect (a reboot is required when
+disabling SELinux, while logging out and back in is enough to have that user
+joining the `KVM` group).
 
 You can now verify if the configuration is correct:
 
@@ -79,93 +103,143 @@ $ groups | grep -ow kvm
 kvm
 ```
 
-#### 4. Setup Kata configuration files
-If the Kata `configuration.toml` file does not exist in `/etc`, do the following:
+### Setup Kata configuration files
+
+If the Kata `configuration.toml` file does not exist in `/etc`, do the
+following:
+
 ```bash
 $ sudo install -D -o ${USER} -g root -m 0640 /usr/share/defaults/kata-containers/configuration.toml /etc/kata-containers
 ```
 
 Or, if the file exists, but is not readable by the user:
+
 ```bash
 $ sudo chown -R a+r /etc/kata-containers/
 ```
 
-#### 5. Disable `vhost-net`
-Disable `vhost-net` in the Kata configuration file, by commenting out the `disable_vhost_net` line:
+### Disable `vhost-net`
+
+Disable `vhost-net` in the Kata configuration file, by commenting out the
+`disable_vhost_net` line:
+
 ```bash
 $ sudo sed -i -e 's/^#disable_vhost_net = true/disable_vhost_net = true/' /etc/kata-containers/configuration.toml
 ```
 
-#### 6. Modify the Kata images permissions
-The Kata images needs to be accessible by the user, so change the permissions of the image directory to be readable by the user.
+### Modify the Kata images permissions
+
+The Kata images needs to be accessible by the user, so change the permissions
+of the image directory to be readable by the user.
+
 ```bash
 $ sudo chown -R a+r /usr/share/kata-containers
 ```
 
-#### 7. Set up Podman rootless configuration
+### Set up Podman rootless configuration
+
 If `libpod.conf` does not exist in `~/.config/containers/`:
+
 ```bash
 $ sudo install -D -o ${USER} -g ${USER} -m 0640 /usr/share/containers/libpod.conf ~/.config/containers/
 ```
 
-By default the `tmp_dir` in `libpod.conf` is set to `/var/run/libpod`, however that is not accessible by a user, so change to the rootless runtime directory.
+By default the `tmp_dir` in `libpod.conf` is set to `/var/run/libpod`, however
+that is not accessible by a user, so change to the rootless runtime directory.
+
 ```bash
 $ sed -i -e "s|^tmp_dir = .*$|tmp_dir = \"$XDG_RUNTIME_DIR/libpod/tmp\"|" ~/.config/containers/libpod.conf
 ```
 
-#### 8. Add Kata Runtime to Podman configuration file (optional)
-You can tell Podman to create or run containers using the Kata runtime with `--runtime=value` flag.
+### Add Kata Runtime to Podman configuration file (optional)
+
+You can tell Podman to create or run containers using the Kata runtime with
+`--runtime=value` flag.
 
 You can directly pass the fully qualified Kata runtime path with:
+
 ```bash
 $ podman run --runtime=/usr/local/bin/kata-runtime ...
 ```
 
-or add a `kata` entry in the `[runtimes]` section of the configuration file by appending the Kata Runtime binary path(s) to the `libpod.conf` file:
+or add a `kata` entry in the `[runtimes]` section of the configuration file by
+appending the Kata Runtime binary path(s) to the `libpod.conf` file:
+
 ```bash
 $ echo 'kata = ["/usr/local/bin/kata-runtime"]' >> ~/.config/containers/libpod.conf
 ```
+
 and then use `kata` as the runtime name:
+
 ```bash
 $ podman run --runtime=kata ...
 ```
 
 > **NOTE:**
-> A less recommended approach could be to have the absolute `kata-runtime` path in the standard `$PATH` location instead of the configuration file, and a binary with that name will be looked up automatically:
-```bash
-kata-runtime = [
-]
-```
+>
+> A less recommended approach could be to have the absolute `kata-runtime`
+> path in the standard `$PATH` location instead of the configuration file, and
+> a binary with that name will be looked up automatically:
+>
+> ```bash
+> kata-runtime = [
+> ]
+> ```
 
-#### 9. Set Kata runtime as Podman's default OCI runtime (optional)
-To avoid using the `--runtime=value` flag set Kata runtime as the default runtime:
+### Set Kata runtime as Podman's default OCI runtime (optional)
+
+To avoid using the `--runtime=value` flag set Kata runtime as the default
+runtime:
+
 ```bash
 $ sed -i -e 's/^runtime = "runc"/runtime = "kata"/' ~/.config/containers/libpod.conf
 ```
 
 ## Run Kata with rootless Podman
+
 ```bash
 $ podman run --rm --runtime=kata alpine date
 ```
 
 > **NOTE:**
+>
 > To obtain debug logs you can:
->  - Enable [debug](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#enable-full-debug) in Kata (logs are added to journald).
+>
+>  - Enable
+>    [debug](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#enable-full-debug)
+>    in Kata (logs are added to journald).
+>
 >  - Pass `--log-level=debug` to Podman (logs are printed to stderr).
 
 ## Appendix: Possible Errors
+
 If you are building from source you may encounter the following errors.
 
 ### Error caused by agent or runtime version mismatch
+
 ```
 rpc error: code = Internal desc = Could not add route dest()/gw(10.0.2.2)/dev(tap0): network is unreachable: OCI runtime error
 ```
-Solution:
-You may need to [rebuild the agent](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#add-a-custom-agent-to-the-image---optional); there was a change in both the [agent](https://github.com/kata-containers/agent/commit/a78e8cfda627cc350dc9d9ca9b969ebb642030c3) and [runtime](https://github.com/kata-containers/runtime/commit/cfedb06a19135e2ab4f18203a4f3147cdc3a4980) code. This would probably only occur if building latest from source, since the runtime version would have the change and the released agent does not.
+
+**Solution:**
+
+You may need to
+[rebuild the agent](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#add-a-custom-agent-to-the-image---optional);
+there was a change in both the
+[agent](https://github.com/kata-containers/agent/commit/a78e8cfda627cc350dc9d9ca9b969ebb642030c3)
+and
+[runtime](https://github.com/kata-containers/runtime/commit/cfedb06a19135e2ab4f18203a4f3147cdc3a4980)
+code. This would probably only occur if building latest from source, since the
+runtime version would have the change and the released agent does not.
 
 ### Missing registry file
+
 ```
 Error: unable to pull alpine: image name provided is a short name and no search registries are defined in the registries config file.
 ```
-Solution:
-The `/etc/containers/registries.conf` file is missing; either use the full image name, or add the [configuration file](https://github.com/containers/libpod/blob/master/install.md#configuration-files).
+
+**Solution:**
+
+The `/etc/containers/registries.conf` file is missing; either use the full
+image name, or add the [configuration
+file](https://github.com/containers/libpod/blob/master/install.md#configuration-files).

--- a/how-to/how-to-use-rootless-kata-containers-with-podman.md
+++ b/how-to/how-to-use-rootless-kata-containers-with-podman.md
@@ -7,6 +7,7 @@
         * [Disable SELinux](#disable-selinux)
         * [Add user to KVM group](#add-user-to-kvm-group)
         * [Reboot](#reboot)
+        * [Setup Kata configuration files](#setup-kata-configuration-files)
         * [Disable `vhost-net`](#disable-vhost-net)
         * [Modify the Kata image permissions](#modify-the-kata-image-permissions)
         * [Set up Podman rootless configuration](#set-up-podman-rootless-configuration)
@@ -24,35 +25,41 @@ user-space networking.
 
 ## Requirements
 
-- A Linux system, see
+- A Linux system
+
+  See
   [supported distributions](https://github.com/kata-containers/documentation/blob/master/install/README.md#supported-distributions)
   for an updated list.
 
-  - If using CentOS 7, `newuidmap` and `newgidmap` do not exist. Install them with:
+  - If using an older distribution such as CentOS 7, `newuidmap` and
+    `newgidmap` will not exist. Install them with:
 
     ```bash
-    $ (git clone https://github.com/shadow-maint/shadow; cd shadow; ./autogen.sh --prefix=/usr --enable-man; make && sudo make -C src install)
-    $ sudo bash -c 'echo 10000 > /proc/sys/user/max_user_namespaces'
-    $ sudo bash -c "echo $(whoami):110000:65536 > /etc/subuid"
-    $ sudo bash -c "echo $(whoami):110000:65536 > /etc/subgid"
+    $ if [ ! -f /etc/subuid ]; then
+    $   (git clone https://github.com/shadow-maint/shadow && cd shadow && ./autogen.sh --prefix=/usr && make && sudo make -C src install)
+    $   sudo bash -c 'echo 10000 > /proc/sys/user/max_user_namespaces'
+    $   sudo bash -c "echo $(whoami):110000:65536 > /etc/subuid"
+    $   sudo bash -c "echo $(whoami):110000:65536 > /etc/subgid"
+    $ fi
     ```
 
-- Golang 1.12
+- Golang version 1.12 or newer.
 
 ## Installation
 
-Refer to the following table for the __minimum__ required software versions
-and the installation instructions:
+Refer to the following table for the *minimum* required software versions and
+the installation instructions:
 
 | Component       | Version       | Install Instructions|
 | ----------------|:-------------:|---------------------|
-| Podman          | 1.6.2         | [see here](https://github.com/containers/libpod/blob/master/install.md)
-| `slirp4netns`   | 0.4.0         | [see here](https://github.com/rootless-containers/slirp4netns#quick-start)
-| Kata Containers | 1.10.0-alpha1 | [see here](https://github.com/kata-containers/documentation/blob/master/install/README.md)
-| Host  Kernel    | 4.14          | 
+| Podman          | 1.6.2         | [see here](https://github.com/containers/libpod/blob/master/install.md) |
+| `slirp4netns`   | 0.4.0         | [see here](https://github.com/rootless-containers/slirp4netns#quick-start) |
+| Kata Containers | 1.10.0-alpha1 | [see here](https://github.com/kata-containers/documentation/blob/master/install/README.md) |
+| Host Kernel     | 4.14          | |
 
-Rootless support for Kata has been verified with `qemu` hypervisor.
-It is recommended to use qemu binary from Kata packages for running rootless containers.
+Rootless support for Kata has been verified with the QEMU hypervisor. It is
+recommended to use the QEMU binary from the Kata packages for running rootless
+containers.
 
 > **NOTE:**
 >
@@ -72,11 +79,11 @@ them for rootless execution.
 > You should understand the security implications before disabling SELinux.
 
 If SELinux is installed and enabled, it needs to be disabled with the
-following command (Kata Containers
-[does not support SELinux](https://github.com/kata-containers/documentation/blob/master/Limitations.md#selinux-support)).
+following command since Kata Containers
+[does not support SELinux](https://github.com/kata-containers/documentation/blob/master/Limitations.md#selinux-support).
 
 > **Warning:**
-> The following command might differ depending on the distro you use:
+> The following command might differ depending on the distribution you use:
 
 ```bash
 $ [ -f /etc/selinux/config ] && sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/selinux/config
@@ -84,27 +91,25 @@ $ [ -f /etc/selinux/config ] && sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /
 
 ### Add user to KVM group
 
-To enable rootless support, the user running the workload needs to be added to the `kvm` group.
+- To enable rootless support, the user running the workload needs to be added
+  to the `kvm` group (which may need to be created as shown):
 
-```bash
-$ sudo usermod -a -G kvm $USER
-```
-> **NOTE:**
->
-> `kvm` should be the group owning the device node `/dev/kvm` on most distros.
-> Make sure the minimum permissions on `/dev/kvm` are as shown below:
-> ```
-> $ ls -la /dev/kvm
-> crw-rw---- 1 root kvm 10, 232 Nov 11 20:28 /dev/kvm
-> ```
-> If the group owner happens to be `root`, you may need to create a system group `kvm` and
-> change permissions for `/dev/kvm` as shown above.
-> ```
-> $ sudo addgroup --system kvm
-> $ sudo chown root:kvm /dev/kvm
-> $ sudo chmod g+rw /dev/kvm
-> ```
- 
+  ```bash
+  $ getent group kvm &>/dev/null || sudo groupadd --system kvm
+  $ sudo usermod -a -G kvm $USER
+  ```
+
+  > **NOTE:**
+  >
+  > The `kvm` group owns the `/dev/kvm` device on most distributions.
+
+- Ensure the `/dev/kvm` device is group owned, readable and writable by the `kvm` group:
+
+  ```bash
+  $ sudo chown root:kvm /dev/kvm
+  $ sudo chmod g+rw /dev/kvm
+  ```
+
 ### Reboot
 
 Reboot the system for the changes to take effect (when you disable SELinux you
@@ -113,82 +118,93 @@ the `kvm` group).
 
 Verify the configuration is correct:
 
-- If installed, disable SELinux:
+- Host kernel minimum version requirement is satisfied
+
   ```bash
-  $ getenforce
-  Disabled
+  $ host_kernel_version=$(uname -r|cut -d. -f1-2)
+  $ result=$(echo "$host_kernel_version >= 4.14"|bc)
+  $ [ "$result" -ne 1 ] && echo "ERROR: host kernel version too old" && exit 1
+  ```
+
+- If installed, ensure SELinux is disabled:
+
+  ```bash
+  $ [ -n "$(command -v getenforce)" ] && [ $(getenforce) != Disabled ] && echo "ERROR: SELinux must be disabled" && exit 1
   ```
 
 - The user should be in the `kvm` group:
 
-  ```
-  $ groups | grep -ow kvm
-  kvm
+  ```bash
+  $ [ -z $(groups | grep -ow kvm) ] && echo "ERROR: user is not a member of the kvm group" && exit 1
   ```
 
 ### Setup Kata configuration files
 
-These next set of instructions are based on Kata Containers being installed from a package manager.
-If `kata-deploy` was used, then the binaries and configuration.toml files will be located at `/opt/kata/` 
-and the following instructions will have to be modified.
-If the Kata `configuration.toml` file does not exist in `/etc`, create it:
+This set of instructions are based on the assumption that Kata Containers has
+been installed using a package manager. If `kata-deploy` was used, the
+binaries and `configuration.toml` files will be located at `/opt/kata/` and
+the following instructions will have to be modified accordingly.
+
+If the Kata `configuration.toml` file does not exist in `/etc`, create it and
+ensure the file is readable by all:
 
 ```bash
-$ sudo mkdir -p /etc/kata-containers/
-$ sudo install -D -m 0640 /usr/share/defaults/kata-containers/configuration.toml /etc/kata-containers/
-```
-
-Or, if the file exists, but is not readable by the user:
-
-```bash
-$ sudo chown -R a+r /etc/kata-containers/
+$ cfg="/etc/kata-containers/configuration.toml"
+$ sudo mkdir -p $(dirname "$cfg")
+$ [ ! -e "$cfg" ] && sudo install -D /usr/share/defaults/kata-containers/configuration.toml $(dirname "$cfg")
+$ sudo chown root:kvm "$cfg"
+$ sudo chmod g+r "$cfg"
 ```
 
 ### Disable `vhost-net`
 
 This step will not be required in case you are using Kata based on the latest source.
 
-Disable `vhost-net` in the Kata configuration file, by commenting out the
+Disable `vhost-net` in the Kata configuration file by commenting out the
 `disable_vhost_net` line:
 
 ```bash
 $ sudo sed -i -e 's/^#disable_vhost_net = true/disable_vhost_net = true/' /etc/kata-containers/configuration.toml
 ```
 
-The above step is required in Kata version 1.10.0-alpha1. In future releases, this should
-no longer be required as Kata runtime should handle this automatically for rootless case.
-This does mean you will get slightly degraded network performance.
+The above step is required in Kata version `1.10.0-alpha1`. In future
+releases, this should no longer be required as the Kata runtime will handle
+this automatically for the rootless case. Disabling `vhost-net` will degrade
+network performance slightly.
 
 ### Modify the Kata image permissions
 
-Upstream qemu needs to have read and write permissions for the kata image in order to 
-use it as a nvdimm memory backend, even though in case of Kata, the image is used purely
-for a read-only operation. 
+Upstream QEMU needs to have read and write permissions for the Kata image in
+order to use it as a NVDIMM memory backend, even though in case of Kata, the
+image is used purely for a read-only operation.
 
-Write access on the image should not be required for a read-only access. We have fixed this
- in the qemu packages that we ship with Kata and plan on upstreaming this fix.
-(Link to the patch : https://github.com/kata-containers/packaging/blob/master/qemu/patches/4.1.x/0002-memory-backend-file-nvdimm-support-read-only-files-a.patch)
+Write access on the image should not be required for a read-only access. We
+have fixed this in the QEMU packages that we ship with Kata and plan on
+up-streaming this fix.
 
-In case you are using a qemu binary provided by your distribution, it is recommended
-that you use an initrd instead of rootfs image file. The reason being, you will need to 
-add write permissions to the rootfs image for the user running the workload, allowing 
-the user to modify the image. 
+(Link to the patch: https://github.com/kata-containers/packaging/blob/master/qemu/patches/4.1.x/0002-memory-backend-file-nvdimm-support-read-only-files-a.patch)
 
-If you still wish to to use the rootfs image instead of initrd,
- you can change the group ownership of the image by choosing a trusted group and adding
- `rw` permissions for that group. Choose a group where members of the group trust each 
-other, as giving write access to the group allows any member of the group to
-modify the image.
+In case you are using a QEMU binary provided by your distribution, it is
+recommended that you use an initrd instead of rootfs image file. The reason
+being, you will need to add write permissions to the rootfs image for the user
+running the workload, allowing the user to modify the image. 
+
+If you still wish to to use the rootfs image instead of initrd, you can change
+the group ownership of the image by choosing a trusted group and adding read
+and write (`rw`) permissions for that group. Choose a group where members of
+the group trust each other, as giving write access to the group allows any
+member of the group to modify the image.
 
 ```bash
-$ # Set $GROUP to a group that is trusted.
-$ img=$(readlink /usr/share/kata-containers/kata-containers.img)
-$ sudo chown -R root:$GROUP /usr/share/kata-containers/$img
-$ sudo chmod -R g+rw /usr/share/kata-containers/$img
+$ TRUSTED_GROUP=kvm
+$ img=$(readlink -f /usr/share/kata-containers/kata-containers.img)
+$ sudo chown -R "root:$TRUSTED_GROUP" "$img"
+$ sudo chmod -R g+rw "$img"
 ```
 > **Warning:**
 >
-> You should understand the security implications of the above step before adding write permissions for the image.
+> You should understand the security implications of the above step before
+> adding write permissions for the image.
 
 ### Set up Podman rootless configuration
 
@@ -213,20 +229,21 @@ You can tell Podman to create or run containers using the Kata runtime with
 You can directly pass the fully qualified Kata runtime path with:
 
 ```bash
-$ podman run --runtime=/usr/bin/kata-runtime ...
+$ podman run --runtime=/usr/bin/kata-runtime alpine date
 ```
 
-or add a `kata` entry in the `[runtimes]` section of the configuration file by
-appending the Kata Runtime binary path(s) to the `libpod.conf` file:
+Alternatively, add a `kata` entry in the `[runtimes]` section of the
+configuration file by appending the Kata Runtime binary path(s) to the
+`libpod.conf` file:
 
 ```bash
 $ echo 'kata = ["/usr/bin/kata-runtime"]' >> ~/.config/containers/libpod.conf
 ```
 
-and then use `kata` as the runtime name:
+You can then specify the runtime name as `kata`:
 
-```bash
-$ podman run --runtime=kata ...
+```
+$ podman run --rm --runtime=kata alpine date
 ```
 
 > **NOTE:**
@@ -235,7 +252,7 @@ $ podman run --runtime=kata ...
 > path in the standard `$PATH` location instead of the configuration file. In
 > this case it looks up a binary with that name automatically:
 >
-> ```bash
+> ```
 > kata-runtime = [
 > ]
 > ```
@@ -295,5 +312,5 @@ Error: unable to pull alpine: image name provided is a short name and no search 
 **Solution:**
 
 The `/etc/containers/registries.conf` file is missing; either use the full
-image name, or add the [configuration
-file](https://github.com/containers/libpod/blob/master/install.md#configuration-files).
+image name, or add the
+[configuration file](https://github.com/containers/libpod/blob/master/install.md#configuration-files).

--- a/how-to/how-to-use-rootless-kata-containers-with-podman.md
+++ b/how-to/how-to-use-rootless-kata-containers-with-podman.md
@@ -108,11 +108,11 @@ Verify the configuration is correct:
 
 ### Setup Kata configuration files
 
-If the Kata `configuration.toml` file does not exist in `/etc`, do the
-following:
+If the Kata `configuration.toml` file does not exist in `/etc`, create it:
 
 ```bash
-$ sudo install -D -o ${USER} -g root -m 0640 /usr/share/defaults/kata-containers/configuration.toml /etc/kata-containers
+$ sudo mkdir -p /etc/kata-containers/
+$ sudo install -D -o ${USER} -g root -m 0640 /usr/share/defaults/kata-containers/configuration.toml /etc/kata-containers/
 ```
 
 Or, if the file exists, but is not readable by the user:
@@ -144,7 +144,7 @@ $ sudo chown -R a+r /usr/share/kata-containers
 If `libpod.conf` does not exist in `~/.config/containers/`:
 
 ```bash
-$ sudo install -D -o ${USER} -g ${USER} -m 0640 /usr/share/containers/libpod.conf ~/.config/containers/
+$ [ -e ~/.config/containers/libpod.conf ] || install -D /usr/share/containers/libpod.conf ~/.config/containers/libpod.conf
 ```
 
 By default the `tmp_dir` in `libpod.conf` is set to `/var/run/libpod`, however
@@ -162,14 +162,14 @@ You can tell Podman to create or run containers using the Kata runtime with
 You can directly pass the fully qualified Kata runtime path with:
 
 ```bash
-$ podman run --runtime=/usr/local/bin/kata-runtime ...
+$ podman run --runtime=/usr/bin/kata-runtime ...
 ```
 
 or add a `kata` entry in the `[runtimes]` section of the configuration file by
 appending the Kata Runtime binary path(s) to the `libpod.conf` file:
 
 ```bash
-$ echo 'kata = ["/usr/local/bin/kata-runtime"]' >> ~/.config/containers/libpod.conf
+$ echo 'kata = ["/usr/bin/kata-runtime"]' >> ~/.config/containers/libpod.conf
 ```
 
 and then use `kata` as the runtime name:


### PR DESCRIPTION
Add a doc explaining how to run Kata Containers rootless using podman.

This replaces PR https://github.com/kata-containers/documentation/pull/553.