### PR TITLE
install: Update Fedora instructions

### DIFF
--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -3,12 +3,7 @@
 1. Install the Kata Containers components with the following commands:
 
    ```bash
-   $ source /etc/os-release
-   $ ARCH=$(arch)
-   $ BRANCH="${BRANCH:-master}"
-   $ sudo dnf -y install dnf-plugins-core
-   $ sudo -E dnf config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/${BRANCH}/Fedora_${VERSION_ID}/home:katacontainers:releases:${ARCH}:${BRANCH}.repo"
-   $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
+   $ sudo dnf -y install kata-runtime
    ```
 
 2. Decide which container manager to use and select the corresponding link that follows:


### PR DESCRIPTION
kata packages are already present on Fedora 31+. Knowing that, there's
no reason to use the packages provided by OpenSUSE.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>