### PR TITLE
docs: Add Debian 10 to distro table

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -42,7 +42,7 @@ Kata is packaged by the Kata community for:
 |Distribution (link to installation guide)                        | Versions                                                                                                          |
 |-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
 |[CentOS](centos-installation-guide.md)                           | 7                                                                                                                 |
-|[Debian](debian-installation-guide.md)                           | 9                                                                                                                 |
+|[Debian](debian-installation-guide.md)                           | 9, 10                                                                                                             |
 |[Fedora](fedora-installation-guide.md)                           | 28, 29, 30                                                                                                        |
 |[openSUSE](opensuse-installation-guide.md)                       | [Leap](opensuse-leap-installation-guide.md) (15, 15.1)<br>[Tumbleweed](opensuse-tumbleweed-installation-guide.md) |
 |[Red Hat Enterprise Linux (RHEL)](rhel-installation-guide.md)    | 7                                                                                                                 |


### PR DESCRIPTION
Now that [1] has landed, update the list of supported distros to include
Debian 10.

[1] - https://github.com/kata-containers/packaging/issues/647

Fixes: #584.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>