### PR TITLE
howto: Update deprecated CRI-O conf option

### DIFF
--- a/how-to/run-kata-with-k8s.md
+++ b/how-to/run-kata-with-k8s.md
@@ -112,10 +112,17 @@ default_workload_trust = "untrusted"
 
 #### Network namespace management
 To enable networking for the workloads run by Kata, CRI-O needs to be configured to
-manage network namespaces, by setting the following key to `true`:
+manage network namespaces, by setting the following key to `true`.
+
+In CRI-O v1.16:
 ```toml
 manage_network_ns_lifecycle = true
 ```
+In CRI-O v1.17+:
+```toml
+manage_ns_lifecycle = true
+```
+
 
 ### containerd with CRI plugin
 


### PR DESCRIPTION
CRI-O config option manage_network_ns_lifecycle is replaced with
manage_ns_lifecycle in 1.17, which determines whether we pin and remove
namespaces and manage their lifecycle.

Fixes #617

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>