### PR TITLE
docs: Update SLES installation guide

### DIFF
--- a/install/sles-installation-guide.md
+++ b/install/sles-installation-guide.md
@@ -5,7 +5,7 @@
    ```bash
    $ ARCH=$(arch)
    $ BRANCH="${BRANCH:-master}"
-   $ sudo -E zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/${BRANCH}/SLE_12_SP3/home:katacontainers:releases:${ARCH}:${BRANCH}.repo"
+   $ sudo -E zypper addrepo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/${BRANCH}/SLE_12_SP4/home:katacontainers:releases:${ARCH}:${BRANCH}.repo"
    $ sudo -E zypper -n --no-gpg-checks install kata-runtime kata-proxy kata-shim
    ```
 


### PR DESCRIPTION
We need to update the SLES installation guide, as we have obs packages
for SLES 12 SP4 and not for SLES 12 SP3.

Fixes #620

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>