### PR TITLE
use-cases: Update documentation for using Nvidia GPU with Kata

### DIFF
--- a/use-cases/Nvidia-GPU-passthrough-and-Kata.md
+++ b/use-cases/Nvidia-GPU-passthrough-and-Kata.md
@@ -199,7 +199,7 @@ Use the following steps to pass an Nvidia GPU device in pass-through mode with K
 
 4. Start a Kata container with GPU device:
    ```
-   $ sudo docker run -it --runtime=kata-runtime --rm --device /dev/vfio/45 centos /bin/bash
+   $ sudo docker run -it --runtime=kata-runtime --cap-add=ALL --device /dev/vfio/45 centos /bin/bash
    ```
 
 5. Run `lspci` within the container to verify the GPU device is seen in the list


### PR DESCRIPTION
When running docker with Nvidia GPU, the option --cap-add=ALL is required.

Fixes: #622

Signed-off-by: Jimmy Xu <jungming.xjm@antfin.com>