### PR TITLE
docs: Fix opensuse installation guide

### DIFF
--- a/install/opensuse-installation-guide.md
+++ b/install/opensuse-installation-guide.md
@@ -6,6 +6,7 @@
    $ source /etc/os-release
    $ DISTRO_REPO=$(sed "s/ /_/g" <<< "$NAME")
    $ [ -n "$VERSION" ] && DISTRO_REPO+="_${VERSION}"
+   $ DISTRO_REPO=$(echo $DISTRO_REPO | tr -d ' ')
    $ ARCH=$(arch)
    $ BRANCH="${BRANCH:-master}"
    $ REPO_ALIAS="kata-${BRANCH}"


### PR DESCRIPTION
This PR fixes the opensuse installation guide, it solves the issue of
having an extra empty space at the end of the distro name which is causing
a failure when we want to add the kata containers repository as we
are looking for http://download.opensuse.org/repositories/home:/katacontainers:/releases:/x86_64:/master/openSUSE_Leap_15.1%20/
which is non existing and it is giving us an error of Valid metadata not found at specified URL.
This PR replaces the URL for a correct one.

Fixes #635

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>