### PR TITLE
Developer-Guide.md editorial changes including:

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -222,8 +222,8 @@ Jun 29 14:51:17 mymachine systemd-journald[346]: Suppressed 4150 messages from /
 ```
 
 This message indicates that a number of log messages from the `docker.service` slice were
-suppressed. In such a case, you can expect to have incomplete logging information
-stored from the Kata Containers components.
+suppressed. In such a case, you can expect to have incomplete logging
+information stored from the Kata Containers components.
 
 #### Disabling `systemd-journald` rate limiting
 


### PR DESCRIPTION
-Edited content for clarity
-Grammar-, syntax-, and spell-checking
-Corrected indentation
-Standardized lines to break at 78 characters
-Used 'Kata Containers' term consistently
Fixes #641
Signed-off-by: Doug Martin <doug.martin@intel.com>