### PR TITLE
Changed one letter

### DIFF
--- a/how-to/how-to-use-virtio-fs-with-kata.md
+++ b/how-to/how-to-use-virtio-fs-with-kata.md
@@ -39,7 +39,7 @@ This will place the Kata release artifacts in `/opt/kata`, and update Docker's c
 
 Once installed, start a new container, utilizing NEMU + `virtiofs`:
 ```bash
-$ docker run --runtime=kata-nemu -it busybox
+$ docker run --runtime=kata-qemu -it busybox
 ```
 
 Verify the new container is running with the NEMU hypervisor as well as using `virtiofsd`. To do this look for the hypervisor path and the `virtiofs` daemon process on the host:


### PR DESCRIPTION
docker run --runtime=kata-nemu -it busybox -> docker run --runtime=kata-qemu -it busybox
I tried to run Kata with VirtioFS but found that this may be a possible typo.

I read the daemon.json generated while update Kata and none printed "nemu". But correct me if I'm wrong.

Regards,
Bryan

P.S. : This is my first time contributing to an open source project