### PR TITLE
docs: Update the paths of minikube installing kata yaml files

### DIFF
--- a/design/kata-api-design.md
+++ b/design/kata-api-design.md
@@ -10,9 +10,14 @@ To fulfill the [Kata design requirements](kata-design-requirements.md), and base
 
 |Name|Description|
 |---|---|
-|`CreateSandbox(SandboxConfig)`| Create and start a sandbox, and return the sandbox structure.|
+|`CreateSandbox(SandboxConfig)`| Create and start a sandbox, create its containers and do not start them, return the sandbox structure.|
 |`FetchSandbox(ID)`| Connect to an existing sandbox and return the sandbox structure.|
 |`ListSandboxes()`| List all existing sandboxes with status. |
+|`StatusSandbox(ID)`| Get the detailed status of a Sandbox. |
+|`StartSandbox(ID)`| Start an existing sandbox and all its containers, return the sandbox structure. |
+|`RunSandbox(SandboxConfig)`| Create and start a sandbox, and then create and start its containers, return the sandbox structure. |
+|`StopSandbox(ID)`| Stop an existing sandbox and destroy all containers within the sandbox, return the sandbox structure. |
+|`DeleteSandbox(ID)`| Stop an already created sandbox and then delete it, return the sandbox structure. |
 
 ### Sandbox Operation API
 

--- a/install/minikube-installation-guide.md
+++ b/install/minikube-installation-guide.md
@@ -128,8 +128,8 @@ configured for you) to deploy them:
 ```sh
 $ git clone https://github.com/kata-containers/packaging.git
 $ cd packaging/kata-deploy
-$ kubectl apply -f kata-rbac.yaml
-$ kubectl apply -f kata-deploy.yaml
+$ kubectl apply -f kata-deploy/base/kata-rbac.yaml
+$ kubectl apply -f kata-rbac/base/kata-deploy.yaml
 ```
 
 This installs the Kata Containers components into `/opt/kata` inside the Minikube node. It can take


### PR DESCRIPTION
The command for intalling kata in minikube still using the old path of
the kata-deploy of the packaging project. This commit update the path of
the kata-deploy in the kata-containers/documentation project.

Fixes: #712
