### PR TITLE
action: Fix in progress issue action

### DIFF
--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -42,28 +42,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_TOKEN }}
         run: |
           pr=${{ github.event.pull_request.number }}
-          linked_issue_urls=$(hub-util.sh list-issue-linked-prs |\
-            grep -v "^\#" |\
-            grep "/pull/${pr};" |\
-            cut -d';' -f2 || true)
+
+          linked_issue_urls=$(hub-util.sh \
+            list-issues-for-pr "$pr" |\
+            grep -v "^\#"  |\
+            cut -d';' -f3 || true)
 
           # PR doesn't have any linked issues
-          # (it should, but maybe a new user forgot to add a "Fixes #" commit).
-          [ -z "$linked_issue_urls" ] \
-            && echo "::error::No linked issues for PR $pr" \
-            && exit 1
+          # (it should, but maybe a new user forgot to add a "Fixes: #XXX" commit).
+          [ -z "$linked_issue_urls" ] && {
+            echo "::error::No linked issues for PR $pr"
+            exit 1
+          }
 
           project_name="Issue backlog"
           project_type="org"
           project_column="In progress"
 
-          for issue_url in $linked_issue_urls
+          for issue_url in $(echo "$linked_issue_urls")
           do
             issue=$(echo "$issue_url"| awk -F\/ '{print $NF}' || true)
 
-            [ -z "$issue" ] \
-              && echo "::error::Cannot determine issue number from $issue_url for PR $pr" \
-              && exit 1
+            [ -z "$issue" ] && {
+              echo "::error::Cannot determine issue number from $issue_url for PR $pr"
+              exit 1
+            }
 
             # Move the issue to the correct column on the project board
             hub-util.sh \


### PR DESCRIPTION
Call `hub-util.sh`'s `list-issues-for-pr` command rather than the slower and unreliable `list-pr-linked-issues` command.

Fixes: #732.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>