### PR TITLE
Update Supported Distributions table and Fedora installation.

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -41,13 +41,12 @@ Kata is packaged by the Kata community for:
 
 |Distribution (link to installation guide)                        | Versions                                                                                                          |
 |-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-|[CentOS](centos-installation-guide.md)                           | 7                                                                                                                 |
+|[CentOS](centos-installation-guide.md)                           | 7, 8                                                                                                              |
 |[Debian](debian-installation-guide.md)                           | 9, 10                                                                                                             |
-|[Fedora](fedora-installation-guide.md)                           | 28, 29, 30                                                                                                        |
+|[Fedora](fedora-installation-guide.md)                           | 30                                                                                                                |
 |[openSUSE](opensuse-installation-guide.md)                       | [Leap](opensuse-leap-installation-guide.md) (15, 15.1)<br>[Tumbleweed](opensuse-tumbleweed-installation-guide.md) |
-|[Red Hat Enterprise Linux (RHEL)](rhel-installation-guide.md)    | 7                                                                                                                 |
-|[SUSE Linux Enterprise Server (SLES)](sles-installation-guide.md)| SLES 12 SP3                                                                                                       |
-|[Ubuntu](ubuntu-installation-guide.md)                           | 16.04, 18.04                                                                                                      |
+|[SUSE Linux Enterprise Server (SLES)](sles-installation-guide.md)| SLES 15 SP1                                                                                                       |
+|[Ubuntu](ubuntu-installation-guide.md)                           | 16.04, 18.04, 20.04                                                                                               |
 
 #### Official packages
 

--- a/install/fedora-installation-guide.md
+++ b/install/fedora-installation-guide.md
@@ -1,15 +1,23 @@
 # Install Kata Containers on Fedora
 
-1. Install the Kata Containers components with the following commands:
+1. Install the Kata Containers components:
 
-   ```bash
-   $ source /etc/os-release
-   $ ARCH=$(arch)
-   $ BRANCH="${BRANCH:-master}"
-   $ sudo dnf -y install dnf-plugins-core
-   $ sudo -E dnf config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/${BRANCH}/Fedora_${VERSION_ID}/home:katacontainers:releases:${ARCH}:${BRANCH}.repo"
-   $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
-   ```
+    - supported by the Kata community with the following commands:
+
+      ```bash
+      $ source /etc/os-release
+      $ ARCH=$(arch)
+      $ BRANCH="${BRANCH:-master}"
+      $ sudo dnf -y install dnf-plugins-core
+      $ sudo -E dnf config-manager --add-repo "http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/${BRANCH}/Fedora_${VERSION_ID}/home:katacontainers:releases:${ARCH}:${BRANCH}.repo"
+      $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
+      ```
+
+    - distributed by Fedora with the following commands:
+
+      ```bash
+      $ sudo -E dnf -y install kata-runtime kata-proxy kata-shim
+      ```
 
 2. Decide which container manager to use and select the corresponding link that follows:
 


### PR DESCRIPTION
Update the Supported Distributions table with what is currently built at http://download.opensuse.org/repositories/home:/katacontainers:/

Include the command to install the Fedora distro packages.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>