### PR TITLE
modify the error url of fluentbit logfmt

### DIFF
--- a/how-to/how-to-import-kata-logs-with-fluentd.md
+++ b/how-to/how-to-import-kata-logs-with-fluentd.md
@@ -185,7 +185,7 @@ in Kibana:
 ![Kata tags in EFK](./images/efk_syslog_entry_detail.png).
 
 We can however further sub-parse the Kata entries using the
-[Fluentd plugins](https://docs.fluentbit.io/manual/parser/logfmt) that will parse
+[Fluentd plugins](https://docs.fluentbit.io/manual/pipeline/parsers/logfmt) that will parse
 `logfmt` formatted data. We can utilise these to parse the sub-fields using a Fluentd filter
 section. At the same time, we will prefix the new fields with `kata_` to make it clear where
 they have come from:


### PR DESCRIPTION
/check-pr-porting-labels
/needs-backport

the error url is https://docs.fluentbit.io/manual/parser/logfmt
the right url is https://docs.fluentbit.io/manual/pipeline/parsers/logfmt