### PR TITLE
docs: add param to sandbox design api

### DIFF
--- a/design/kata-api-design.md
+++ b/design/kata-api-design.md
@@ -23,34 +23,35 @@ To fulfill the [Kata design requirements](kata-design-requirements.md), and base
 
 |Name|Description|
 |---|---|
-|`sandbox.Delete()`| Destroy the sandbox and remove all persistent metadata.|
+|`sandbox.Delete()`| Shut down the VM in which the sandbox, and destroy the sandbox and remove all persistent metadata.|
 |`sandbox.Monitor()`| Return a context handler for caller to monitor sandbox callbacks such as error termination.|
 |`sandbox.Release()`| Release a sandbox data structure, close connections to the agent, and quit any goroutines associated with the sandbox. Mostly used for daemon restart.|
 |`sandbox.Start()`| Start a a sandbox and the containers making the sandbox.|
-|`sandbox.Status()`| Get the status of the sandbox and containers.|
-|`sandbox.Stop()`| Stop a sandbox and Destroy the containers in the sandbox..|
-|`sandbox.CreateContainer()`| Create new container in the sandbox.|
-|`sandbox.DeleteContainer()`| Delete a container from the sandbox.|
-|`sandbox.EnterContainer()`| Run a new process in a container.|
-|`sandbox.KillContainer()`| Signal a container in the sandbox.|
-|`sandbox.PauseContainer()`| Pause a running container in the sandbox.|
-|`sandbox.ProcessListContainer()`| List every process running inside a specific container in the sandbox.|
-|`sandbox.ResumeContainer()`| Resume a paused container in the sandbox.|
-|`sandbox.StartContainer()`| Start a container in the sandbox.|
-|`sandbox.StatsContainer()`| Return the stats of a running container.|
-|`sandbox.StatusContainer()`| Get the status of a container in the sandbox.|
-|`sandbox.StopContainer()`| Stop a container in the sandbox.|
-|`sandbox.UpdateContainer()`| Update a running container in the sandbox.|
-|`sandbox.WaitProcess()`| Wait on a process to terminate.|
+|`sandbox.Stats()`| Get the stats of a running sandbox, return a `SandboxStats` structure.|
+|`sandbox.Status()`| Get the status of the sandbox and containers, return a `SandboxStatus` structure.|
+|`sandbox.Stop(force)`| Stop a sandbox and Destroy the containers in the sandbox. When force is true, ignore guest related stop failures.|
+|`sandbox.CreateContainer(conf)`| Create new container in the sandbox with the `ContainerConfig` parameter. It will add new container config to `sandbox.config.Containers`.|
+|`sandbox.DeleteContainer(contID)`| Delete a container from the sandbox by `contID`, return a `Container` structure.|
+|`sandbox.EnterContainer(containerID, cmd)`| Run a new process in a container, executing customer's `types.Cmd` command.|
+|`sandbox.KillContainer(contID, signal, all)`| Signal a container in the sandbox by the `contID`.|
+|`sandbox.PauseContainer(contID)`| Pause a running container in the sandbox by the `contID`.|
+|`sandbox.ProcessListContainer(containerID, options)`| List every process running inside a specific container in the sandbox, return a `ProcessList` structure.|
+|`sandbox.ResumeContainer(contID)`| Resume a paused container in the sandbox by the `contID`.|
+|`sandbox.StartContainer(contID)`| Start a container in the sandbox by the `contID`.|
+|`sandbox.StatsContainer(contID)`| Get the stats of a running container, return a `ContainerStats` structure.|
+|`sandbox.StatusContainer(contID)`| Get the status of a container in the sandbox, return a `ContainerStatus` structure.|
+|`sandbox.StopContainer(contID, force)`| Stop a container in the sandbox by the `contID`.|
+|`sandbox.UpdateContainer(containerID, resources)`| Update a running container in the sandbox.|
+|`sandbox.WaitProcess(containerID, processID)`| Wait on a process to terminate.|
 ### Sandbox Hotplug API
 |Name|Description|
 |---|---|
-|`sandbox.AddDevice()`| Add new storage device to the sandbox.|
-|`sandbox.AddInterface()`| Add new NIC to the sandbox.|
-|`sandbox.RemoveInterface()`| Remove a NIC from the sandbox.|
-|`sandbox.ListInterfaces()`| List all NICs and their configurations in the sandbox.|
-|`sandbox.UpdateRoutes()`| Update the sandbox route table (e.g. for portmapping support).|
-|`sandbox.ListRoutes()`| List the sandbox route table.|
+|`sandbox.AddDevice(info)`| Add new storage device `DeviceInfo` to the sandbox, return a `Device` structure.|
+|`sandbox.AddInterface(inf)`| Add new NIC to the sandbox.|
+|`sandbox.RemoveInterface(inf)`| Remove a NIC from the sandbox.|
+|`sandbox.ListInterfaces()`| List all NICs and their configurations in the sandbox, return a `pbTypes.Interface` list.|
+|`sandbox.UpdateRoutes(routes)`| Update the sandbox route table (e.g. for portmapping support), return a `pbTypes.Route` list.|
+|`sandbox.ListRoutes()`| List the sandbox route table, return a `pbTypes.Route` list.|
 
 ### Sandbox Relay API
 |Name|Description|


### PR DESCRIPTION
Add param to sandbox design apis doc. Update kata-api-design.md file,
the apis for the sandbox operations.
link to: https://github.com/kata-containers/documentation/issues/727

Fixes: #729

Signed-off-by: Ychau Wang <wangyongchao.bj@inspur.com>