### PR TITLE
modify the error url of logfmt

### DIFF
--- a/how-to/how-to-use-kata-containers-with-acrn.md
+++ b/how-to/how-to-use-kata-containers-with-acrn.md
@@ -27,7 +27,7 @@ This document requires the presence of the ACRN hypervisor and Kata Containers o
 
 - ACRN supported [Hardware](https://projectacrn.github.io/latest/hardware.html#supported-hardware).
   > **Note:** Please make sure to have a minimum of 4 logical processors (HT) or cores.
-- ACRN [software](https://projectacrn.github.io/latest/tutorials/kbl-nuc-sdc.html#use-the-script-to-set-up-acrn-automatically) setup.
+- ACRN [software](https://projectacrn.github.io/1.6/tutorials/kbl-nuc-sdc.html#use-the-script-to-set-up-acrn-automatically) setup.
 - For networking, ACRN supports either MACVTAP or TAP. If MACVTAP is not enabled in the Service OS, please follow the below steps to update the kernel:
 
   ```sh

--- a/how-to/how-to-use-virtio-mem-with-kata.md
+++ b/how-to/how-to-use-virtio-mem-with-kata.md
@@ -20,7 +20,7 @@ Please use following unofficial version of the Linux kernel and QEMU that suppor
 The Linux kernel is at https://github.com/davidhildenbrand/linux/tree/virtio-mem-rfc-v4.
 The Linux kernel config that can work with Kata Containers is at https://gist.github.com/teawater/016194ee84748c768745a163d08b0fb9.
 
-The QEMU is at https://github.com/teawater/qemu/tree/kata-virtio-mem. (The original source is at https://github.com/davidhildenbrand/qemu/tree/virtio-mem.  Its base version of QEMU cannot work with Kata Containers.  So merge the commit of `virtio-mem` to upstream QEMU.)
+The QEMU is at https://github.com/teawater/qemu/tree/kata-virtio-mem. (The original source is at https://github.com/davidhildenbrand/qemu/tree/virtio-mem-vfio.  Its base version of QEMU cannot work with Kata Containers.  So merge the commit of `virtio-mem` to upstream QEMU.)
 
 Set Linux and the QEMU that support `virtio-mem` with following line in the Kata Containers QEMU configuration `configuration-qemu.toml`:
 ```toml

--- a/how-to/service-mesh.md
+++ b/how-to/service-mesh.md
@@ -76,7 +76,7 @@ is not able to perform a proper setup of the rules.
 
 ### Service Mesh Istio
 
-As a reference, you can follow Istio [instructions](https://istio.io/docs/setup/kubernetes/quick-start/#download-and-prepare-for-the-installation).
+As a reference, you can follow Istio [instructions](https://istio.io/latest/docs/setup/getting-started/#download-and-prepare-for-the-installation).
 
 The following is a summary of what you need to install Istio on your system:
 ```

--- a/install/docker/opensuse-leap-docker-install.md
+++ b/install/docker/opensuse-leap-docker-install.md
@@ -7,7 +7,7 @@ You can ignore the content of this comment.
 
 ```bash
 $ echo "NOTE: this document is just a link to the generic openSUSE install guide located at:
-https://raw.githubusercontent.com/kata-containers/documentation/master/install/docker/opensuse-docker-install.md
+https://github.com/kata-containers/documentation/tree/master/install/docker/opensuse-docker-install.md
 
 Please download this file and run kata-doc-to-script.sh again."
 ```

--- a/install/docker/opensuse-tumbleweed-docker-install.md
+++ b/install/docker/opensuse-tumbleweed-docker-install.md
@@ -7,7 +7,7 @@ You can ignore the content of this comment.
 
 ```bash
 $ echo "NOTE: this document is just a link to the generic openSUSE install guide located at:
-https://raw.githubusercontent.com/kata-containers/documentation/master/install/docker/opensuse-docker-install.md
+https://github.com/kata-containers/documentation/tree/master/install/docker/opensuse-docker-install.md
 
 Please download this file and run kata-doc-to-script.sh again."
 ```

--- a/install/installing-with-kata-doc-to-script.md
+++ b/install/installing-with-kata-doc-to-script.md
@@ -17,7 +17,7 @@ to generate installation bash scripts.
 
 ```bash
 $ source /etc/os-release
-$ curl -fsSL -O https://raw.githubusercontent.com/kata-containers/documentation/master/install/${ID}-installation-guide.md
+$ curl -fsSL -O https://github.com/kata-containers/documentation/tree/master/install/${ID}-installation-guide.md
 $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/tests/master/.ci/kata-doc-to-script.sh) ${ID}-installation-guide.md ${ID}-install.sh"
 ```
 
@@ -33,7 +33,7 @@ $ bash "./${ID}-install.sh"
 
 ```bash
 $ source /etc/os-release
-$ curl -fsSL -O https://raw.githubusercontent.com/kata-containers/documentation/master/install/docker/${ID}-docker-install.md
+$ curl -fsSL -O https://github.com/kata-containers/documentation/tree/master/install/docker${ID}-docker-install.md
 $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/tests/master/.ci/kata-doc-to-script.sh) ${ID}-docker-install.md ${ID}-docker-install.sh"
 ```
 

--- a/install/opensuse-leap-installation-guide.md
+++ b/install/opensuse-leap-installation-guide.md
@@ -8,7 +8,7 @@ You can ignore the content of this comment.
 
 ```bash
 $ echo "NOTE: this document is just a link to the generic openSUSE install guide located at:
-https://raw.githubusercontent.com/kata-containers/documentation/master/install/opensuse-installation-guide.md
+https://github.com/kata-containers/documentation/tree/master/install/opensuse-installation-guide.md
 
 Please download this file and run kata-doc-to-script.sh again."
 ```

--- a/install/opensuse-tumbleweed-installation-guide.md
+++ b/install/opensuse-tumbleweed-installation-guide.md
@@ -8,7 +8,7 @@ You can ignore the content of this comment.
 
 ```bash
 $ echo "NOTE: this document is just a link to the generic openSUSE install guide located at:
-https://raw.githubusercontent.com/kata-containers/documentation/master/install/opensuse-installation-guide.md
+https://github.com/kata-containers/documentation/tree/master/install/opensuse-installation-guide.md
 
 Please download this file and run kata-doc-to-script.sh again."
 ```


### PR DESCRIPTION
docs: modify the error url of logfmt

There are many error urls, which will affect the correctness of the document. I changed the error url to the correct url.

Fixes: https://github.com/kata-containers/documentation/issues/740

Signed-off-by: Cria Hu  <huyuqing@inspur.com>