### PR TITLE
docs: Add a link to document describing how to use annotations

### DIFF
--- a/how-to/how-to-load-kernel-modules-with-kata.md
+++ b/how-to/how-to-load-kernel-modules-with-kata.md
@@ -56,8 +56,9 @@ There are some limitations with this approach:
 
 As was mentioned above, not all containers need the same modules, therefore using
 the configuration file for specifying the list of kernel modules per [POD][3] can
-be a pain. Unlike the configuration file, annotations provide a way to specify
-custom configurations per POD.
+be a pain.
+Unlike the configuration file, [annotations](how-to-set-sandbox-config-kata.md)
+provide a way to specify custom configurations per POD.
 
 The list of kernel modules and parameters can be set using the annotation
 `io.katacontainers.config.agent.kernel_modules` as a semicolon separated


### PR DESCRIPTION
Add a link to the document listing the available annotations

Fixes: #756

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>