### PR TITLE
documentation: Add a direct link to spell-checking documentation

### DIFF
--- a/Documentation-Requirements.md
+++ b/Documentation-Requirements.md
@@ -208,8 +208,8 @@ that checks both dictionary words and the additional terms we use.
 Run the spell checking tool on your document before raising a PR to ensure it
 is free of mistakes.
 
-If your document introduces new terms, you need to update the custom
-dictionary used by the spell checking tool to incorporate the new words.
+If your document introduces new terms, you need to [update the custom
+dictionary](https://github.com/kata-containers/tests/tree/master/cmd/check-spelling#adding-a-new-word) used by the spell checking tool to incorporate the new words.
 
 # Names
 


### PR DESCRIPTION
The CI points to this documentation when there is a spelling failure, but that
document does not explain how to actually add a word to the
dictionary (althouygh it points to the tool).

Adding a link directly to the section makes it easier to follow the process.

Fixes: #768

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>